### PR TITLE
revert z-move button size

### DIFF
--- a/_css/dark_ap_calc.css
+++ b/_css/dark_ap_calc.css
@@ -257,6 +257,10 @@ select.toxic-counter {
   margin-left: 0.3em;
 }
 
+.poke-info .z-btn {
+  width: 3.5em;
+}
+
 .poke-info .ev-total {
   font-size: 0.8em;
 }

--- a/_scripts/move_data.js
+++ b/_scripts/move_data.js
@@ -1256,14 +1256,6 @@ var MOVES_GSC = $.extend(true, {}, MOVES_RBY, {
 });
 
 var MOVES_ADV = $.extend(true, {}, MOVES_GSC, {
-	"Mega Drain": {
-		"bp": 40,
-		"type": "Grass",
-		"category": "Special",
-		"givesHealth": true,
-		"percentHealed": 0.5,
-		"acc": 100
-	},
 	"Aerial Ace": {
 		"bp": 60,
 		"type": "Flying",
@@ -1563,6 +1555,14 @@ var MOVES_ADV = $.extend(true, {}, MOVES_GSC, {
 		"type": "Psychic",
 		"acc": 100
 	},
+	"Mega Drain": {
+		"bp": 40,
+		"type": "Grass",
+		"category": "Special",
+		"givesHealth": true,
+		"percentHealed": 0.5,
+		"acc": 100
+	},
 	"Memento": {
 		"bp": 0,
 		"type": "Dark"
@@ -1765,6 +1765,12 @@ var MOVES_ADV = $.extend(true, {}, MOVES_GSC, {
 		"type": "Normal",
 		"category": "Physical",
 		"makesContact": true
+	},
+	"Spit Up": {
+		"bp": 1,
+		"type": "Normal",
+		"category": "Special",
+		"acc": 100
 	},
 	"Snatch": {
 		"bp": 0,
@@ -2290,7 +2296,8 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
 	},
 	"Metal Burst": {
 		"bp": 0,
-		"type": "Steel"
+		"type": "Steel",
+		"category": "Physical"
 	},
 	"Miracle Eye": {
 		"bp": 0,
@@ -3291,6 +3298,10 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
 		"type": "Electric"
 	},
 	"Electric Terrain": {
+		"bp": 0,
+		"type": "Electric"
+	},
+	"Electrify": {
 		"bp": 0,
 		"type": "Electric"
 	},

--- a/honkalculate.html
+++ b/honkalculate.html
@@ -415,7 +415,7 @@ title: Battle Facilities Mass Calculator
                         <option value="Special">Special</option>
                     </select>
                     <input class="move-crit calc-trigger btn-input" type="checkbox" id="critL1" /><label class="btn crit-btn" for="critL1" title="Force this attack to be a critical hit?">Crit</label>
-                    <input class="move-z calc-trigger btn-input" type="checkbox" id="zL1" /><label class="btn x-btn gen-specific g7 g20 g21" for="zL1" title="Use the corresponding Z-Move?">Z-Move</label>
+                    <input class="move-z calc-trigger btn-input" type="checkbox" id="zL1" /><label class="btn x-btn z-btn gen-specific g7 g20 g21" for="zL1" title="Use the corresponding Z-Move?">Z-Move</label>
                     <input class="move-max calc-trigger btn-input" type="checkbox" id="maxL1" /><label class="btn x-btn gen-specific g8" for="maxL1" title="Use the corresponding Max Move?">Max</label>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
@@ -433,7 +433,7 @@ title: Battle Facilities Mass Calculator
                         <option value="Special">Special</option>
                     </select>
                     <input class="move-crit calc-trigger btn-input" type="checkbox" id="critL2" /><label class="btn crit-btn" for="critL2" title="Force this attack to be a critical hit?">Crit</label>
-                    <input class="move-z calc-trigger btn-input" type="checkbox" id="zL2" /><label class="btn x-btn gen-specific g7 g20 g21" for="zL2" title="Use the corresponding Z-Move?">Z-Move</label>
+                    <input class="move-z calc-trigger btn-input" type="checkbox" id="zL2" /><label class="btn x-btn z-btn gen-specific g7 g20 g21" for="zL2" title="Use the corresponding Z-Move?">Z-Move</label>
                     <input class="move-max calc-trigger btn-input" type="checkbox" id="maxL2" /><label class="btn x-btn gen-specific g8" for="maxL2" title="Use the corresponding Max Move?">Max</label>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
@@ -451,7 +451,7 @@ title: Battle Facilities Mass Calculator
                         <option value="Special">Special</option>
                     </select>
                     <input class="move-crit calc-trigger btn-input" type="checkbox" id="critL3" /><label class="btn crit-btn" for="critL3" title="Force this attack to be a critical hit?">Crit</label>
-                    <input class="move-z calc-trigger btn-input" type="checkbox" id="zL3" /><label class="btn x-btn gen-specific g7 g20 g21" for="zL3" title="Use the corresponding Z-Move?">Z-Move</label>
+                    <input class="move-z calc-trigger btn-input" type="checkbox" id="zL3" /><label class="btn x-btn z-btn gen-specific g7 g20 g21" for="zL3" title="Use the corresponding Z-Move?">Z-Move</label>
                     <input class="move-max calc-trigger btn-input" type="checkbox" id="maxL3" /><label class="btn x-btn gen-specific g8" for="maxL3" title="Use the corresponding Max Move?">Max</label>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
@@ -469,7 +469,7 @@ title: Battle Facilities Mass Calculator
                         <option value="Special">Special</option>
                     </select>
                     <input class="move-crit calc-trigger btn-input" type="checkbox" id="critL4" /><label class="btn crit-btn" for="critL4" title="Force this attack to be a critical hit?">Crit</label>
-                    <input class="move-z calc-trigger btn-input" type="checkbox" id="zL4" /><label class="btn x-btn gen-specific g7 g20 g21" for="zL4" title="Use the corresponding Z-Move?">Z-Move</label>
+                    <input class="move-z calc-trigger btn-input" type="checkbox" id="zL4" /><label class="btn x-btn z-btn gen-specific g7 g20 g21" for="zL4" title="Use the corresponding Z-Move?">Z-Move</label>
                     <input class="move-max calc-trigger btn-input" type="checkbox" id="maxL4" /><label class="btn x-btn gen-specific g8" for="maxL4" title="Use the corresponding Max Move?">Max</label>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>

--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@ title: Battle Facilities Calculator
 					<option value="Special">Special</option>
 				</select>
 				<input class="move-crit calc-trigger btn-input" type="checkbox" id="critL1" /><label class="btn crit-btn" for="critL1" title="Force this attack to be a critical hit?">Crit</label>
-				<input class="move-z calc-trigger btn-input" type="checkbox" id="zL1" /><label class="btn x-btn gen-specific g7 g20 g21" for="zL1" title="Use the corresponding Z-Move?">Z-Move</label>
+				<input class="move-z calc-trigger btn-input" type="checkbox" id="zL1" /><label class="btn x-btn z-btn gen-specific g7 g20 g21" for="zL1" title="Use the corresponding Z-Move?">Z-Move</label>
 				<input class="move-max calc-trigger btn-input" type="checkbox" id="maxL1" /><label class="btn x-btn gen-specific g8" for="maxL1" title="Use the corresponding Max Move?">Max</label>
 				<select class="move-hits calc-trigger hide">
 					<option value="2">2 hits</option>
@@ -416,7 +416,7 @@ title: Battle Facilities Calculator
 					<option value="Special">Special</option>
 				</select>
 				<input class="move-crit calc-trigger btn-input" type="checkbox" id="critL2" /><label class="btn crit-btn" for="critL2" title="Force this attack to be a critical hit?">Crit</label>
-				<input class="move-z calc-trigger btn-input" type="checkbox" id="zL2" /><label class="btn x-btn gen-specific g7 g20 g21" for="zL2" title="Use the corresponding Z-Move?">Z-Move</label>
+				<input class="move-z calc-trigger btn-input" type="checkbox" id="zL2" /><label class="btn x-btn z-btn gen-specific g7 g20 g21" for="zL2" title="Use the corresponding Z-Move?">Z-Move</label>
 				<input class="move-max calc-trigger btn-input" type="checkbox" id="maxL2" /><label class="btn x-btn gen-specific g8" for="maxL2" title="Use the corresponding Max Move?">Max</label>
 				<select class="move-hits calc-trigger hide">
 					<option value="2">2 hits</option>
@@ -434,7 +434,7 @@ title: Battle Facilities Calculator
 					<option value="Special">Special</option>
 				</select>
 				<input class="move-crit calc-trigger btn-input" type="checkbox" id="critL3" /><label class="btn crit-btn" for="critL3" title="Force this attack to be a critical hit?">Crit</label>
-				<input class="move-z calc-trigger btn-input" type="checkbox" id="zL3" /><label class="btn x-btn gen-specific g7 g20 g21" for="zL3" title="Use the corresponding Z-Move?">Z-Move</label>
+				<input class="move-z calc-trigger btn-input" type="checkbox" id="zL3" /><label class="btn x-btn z-btn gen-specific g7 g20 g21" for="zL3" title="Use the corresponding Z-Move?">Z-Move</label>
 				<input class="move-max calc-trigger btn-input" type="checkbox" id="maxL3" /><label class="btn x-btn gen-specific g8" for="maxL3" title="Use the corresponding Max Move?">Max</label>
 				<select class="move-hits calc-trigger hide">
 					<option value="2">2 hits</option>
@@ -452,7 +452,7 @@ title: Battle Facilities Calculator
 					<option value="Special">Special</option>
 				</select>
 				<input class="move-crit calc-trigger btn-input" type="checkbox" id="critL4" /><label class="btn crit-btn" for="critL4" title="Force this attack to be a critical hit?">Crit</label>
-				<input class="move-z calc-trigger btn-input" type="checkbox" id="zL4" /><label class="btn x-btn gen-specific g7 g20 g21" for="zL4" title="Use the corresponding Z-Move?">Z-Move</label>
+				<input class="move-z calc-trigger btn-input" type="checkbox" id="zL4" /><label class="btn x-btn z-btn gen-specific g7 g20 g21" for="zL4" title="Use the corresponding Z-Move?">Z-Move</label>
 				<input class="move-max calc-trigger btn-input" type="checkbox" id="maxL4" /><label class="btn x-btn gen-specific g8" for="maxL4" title="Use the corresponding Max Move?">Max</label>
 				<select class="move-hits calc-trigger hide">
 					<option value="2">2 hits</option>
@@ -1047,7 +1047,7 @@ title: Battle Facilities Calculator
 						<option value="Special">Special</option>
 					</select>
 					<input class="move-crit calc-trigger btn-input" type="checkbox" id="critR1" /><label class="btn crit-btn" for="critR1" title="Force this attack to be a critical hit?">Crit</label>
-					<input class="move-z calc-trigger btn-input" type="checkbox" id="zR1" /><label class="btn x-btn gen-specific g7 g20 g21" for="zR1" title="Use the corresponding Z-Move?">Z-Move</label>
+					<input class="move-z calc-trigger btn-input" type="checkbox" id="zR1" /><label class="btn x-btn z-btn gen-specific g7 g20 g21" for="zR1" title="Use the corresponding Z-Move?">Z-Move</label>
 					<input class="move-max calc-trigger btn-input" type="checkbox" id="maxR1" /><label class="btn x-btn gen-specific g8" for="maxR1" title="Use the corresponding Max Move?">Max</label>
 					<select class="move-hits calc-trigger hide">
 						<option value="2">2 hits</option>
@@ -1065,7 +1065,7 @@ title: Battle Facilities Calculator
 						<option value="Special">Special</option>
 					</select>
 					<input class="move-crit calc-trigger btn-input" type="checkbox" id="critR2" /><label class="btn crit-btn" for="critR2" title="Force this attack to be a critical hit?">Crit</label>
-					<input class="move-z calc-trigger btn-input" type="checkbox" id="zR2" /><label class="btn x-btn gen-specific g7 g20 g21" for="zR2" title="Use the corresponding Z-Move?">Z-Move</label>
+					<input class="move-z calc-trigger btn-input" type="checkbox" id="zR2" /><label class="btn x-btn z-btn gen-specific g7 g20 g21" for="zR2" title="Use the corresponding Z-Move?">Z-Move</label>
 					<input class="move-max calc-trigger btn-input" type="checkbox" id="maxR2" /><label class="btn x-btn gen-specific g8" for="maxR2" title="Use the corresponding Max Move?">Max</label>
 					<select class="move-hits calc-trigger hide">
 						<option value="2">2 hits</option>
@@ -1083,7 +1083,7 @@ title: Battle Facilities Calculator
 						<option value="Special">Special</option>
 					</select>
 					<input class="move-crit calc-trigger btn-input" type="checkbox" id="critR3" /><label class="btn crit-btn" for="critR3" title="Force this attack to be a critical hit?">Crit</label>
-					<input class="move-z calc-trigger btn-input" type="checkbox" id="zR3" /><label class="btn x-btn gen-specific g7 g20 g21" for="zR3" title="Use the corresponding Z-Move?">Z-Move</label>
+					<input class="move-z calc-trigger btn-input" type="checkbox" id="zR3" /><label class="btn x-btn z-btn gen-specific g7 g20 g21" for="zR3" title="Use the corresponding Z-Move?">Z-Move</label>
 					<input class="move-max calc-trigger btn-input" type="checkbox" id="maxR3" /><label class="btn x-btn gen-specific g8" for="maxR3" title="Use the corresponding Max Move?">Max</label>
 					<select class="move-hits calc-trigger hide">
 						<option value="2">2 hits</option>
@@ -1101,7 +1101,7 @@ title: Battle Facilities Calculator
 						<option value="Special">Special</option>
 					</select>
 					<input class="move-crit calc-trigger btn-input" type="checkbox" id="critR4" /><label class="btn crit-btn" for="critR4" title="Force this attack to be a critical hit?">Crit</label>
-					<input class="move-z calc-trigger btn-input" type="checkbox" id="zR4" /><label class="btn x-btn gen-specific g7 g20 g21" for="zR4" title="Use the corresponding Z-Move?">Z-Move</label>
+					<input class="move-z calc-trigger btn-input" type="checkbox" id="zR4" /><label class="btn x-btn z-btn gen-specific g7 g20 g21" for="zR4" title="Use the corresponding Z-Move?">Z-Move</label>
 					<input class="move-max calc-trigger btn-input" type="checkbox" id="maxR4" /><label class="btn x-btn gen-specific g8" for="maxR4" title="Use the corresponding Max Move?">Max</label>
 					<select class="move-hits calc-trigger hide">
 						<option value="2">2 hits</option>


### PR DESCRIPTION
Due to x-btn having its width reduced, the z-move button text included a line break.
The move data now includes all moves used by RS mons so now the calc is a little closer to being able to be used as a complete RS lookup. Items and kinda sorta abilities are the only other things for this. Spit Up and Electrify were the only moves missing.