### PR TITLE
Improve mass calc preformance

### DIFF
--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -68,19 +68,25 @@ function performCalculations() {
 	var setOptions = getSetOptions();
 	var dataSet = [];
 	var pokeInfo = $("#p1");
+	var userPoke = new Pokemon(pokeInfo);
+	var startingBoosts = userPoke.boosts;
 	var counter = 0;
 	for (var i = 0; i < setOptions.length; i++) {
 		var setOptionsID = setOptions[i].id; // speciesName (setName)
 		if (!setOptionsID || setOptionsID.indexOf("Blank Set") !== -1) {
 			continue;
 		}
-		setPokemon = new Pokemon(setOptionsID); 
-		var setName = setOptionsID.substring(setOptionsID.indexOf("(") + 1, setOptionsID.length - 1);
-		if (SETDEX_CUSTOM[setPokemon.name][setName]) {
-			continue;
-		}
+		
+		setPokemon = new Pokemon(setOptionsID);
 		setTier = setPokemon.tier;
-		if (selectedTier === setTier || selectedTier === "All") { // setPokemon.tier can currently be: 28, 40, Tower, RS, SM, DM, SMDM
+		if (selectedTier === setTier) { // setPokemon.tier can currently be: 28, 40, Tower, RS, SM, DM, SMDM
+			// let set be calculated
+		}
+		else if (selectedTier === "All") {
+			var customDexSpecies = SETDEX_CUSTOM[setPokemon.name];
+			if ((customDexSpecies !== undefined) && customDexSpecies[setOptionsID.substring(setOptionsID.indexOf("(") + 1, setOptionsID.length - 1)]) {
+				continue;
+			}
 			// let set be calculated
 		}
 		else if (gen == 80 && setTier === "SMDM") {
@@ -93,11 +99,10 @@ function performCalculations() {
 		var field = new Field();
 		if (mode === "one-vs-all") {
 			defender = setPokemon;
-			attacker = new Pokemon(pokeInfo); // look into keeping a single Pokemon(pokeInfo) object in memory, instead of creating a thousand
-			// look into what can modify the Pokemon object
+			attacker = userPoke;
 		} else {
 			attacker = setPokemon;
-			defender = new Pokemon(pokeInfo);
+			defender = userPoke;
 		}
 		if (attacker.ability === "Rivalry") {
 			attacker.gender = "N";
@@ -139,6 +144,8 @@ function performCalculations() {
 		data.push(((mode === "one-vs-all") ? defender.item : attacker.item) || "");
 		dataSet.push(data);
 		counter++;
+		userPoke.boosts = startingBoosts;
+		userPoke.stats = [];
 	}
 	var pokemon = mode === "one-vs-all" ? attacker : defender;
 	table.rows.add(dataSet).draw();

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -57,7 +57,7 @@ $(".tera").bind("keyup change", function () {
 	var pokeInfo = $(this).closest(".poke-info");
 	if ($(this).prop("checked")) {
 		pokeInfo.find(".type1").val(pokeInfo.find(".tera-type").val());
-		pokeInfo.find(".type2").val("(none)");
+		pokeInfo.find(".type2").val("None");
 	}
 	else {
 		var setName = pokeInfo.find("input.set-selector").val();
@@ -842,6 +842,15 @@ function getMoveDetails(moveInfo, item, species) {
 		}
 
 		var tempType = defaultDetails.type;
+		var ability = moveInfo.closest(".poke-info").find(".ability").val();
+		// changing the type like this prevents getDamageResult() from applying the -ate boost, which is accurate to the game
+		if (ability === "Pixilate" && tempType === "Normal") {
+			maxMoveName = "Max Starfall";
+			tempType = "Fairy";
+		} else if (ability === "Refrigerate" && tempType === "Normal") {
+			maxMoveName = "Max Hailstorm";
+			tempType = "Ice";
+		}
 
 		if (tempBP == 0) {
 			maxMoveName = "Max Guard";


### PR DESCRIPTION
- Changed a few mechanics for accuracy, mostly relating to -ate abilities (like Pixilate).
- I broke the mass calc in "All sets mode" when I fixed it calcing against custom sets. Oops. That's fixed.
- Improved mass calc performance. Using all 996 of USUM's sets as the baseline, it used to take around 5000ms to calc all sets. It now takes 1750ms, an improvement of about 65% in this case.