### PR TITLE
General correctness update

### DIFF
--- a/_scripts/ap_calc.js
+++ b/_scripts/ap_calc.js
@@ -7,6 +7,7 @@ $("#p2 .ability").bind("keyup change", function () {
 
 $("#p2 .item").bind("keyup change", function () {
 	autosetStatus("#p2", $(this).val());
+	autoSetMultiHits($(this).closest(".poke-info"));
 });
 
 var resultLocations = [[], []];

--- a/_scripts/damage.js
+++ b/_scripts/damage.js
@@ -108,10 +108,19 @@ function getDamageResult(attacker, defender, move, field) {
 
 	var defAbility = defender.ability;
 	if (["Mold Breaker", "Teravolt", "Turboblaze"].indexOf(attacker.ability) !== -1 && defAbility !== "Shadow Shield") {
-		defAbility = "";
-		description.attackerAbility = attacker.ability;
-	} else if (["Moongeist Beam", "Sunsteel Strike", "Searing Sunraze Smash", "Menacing Moonraze Maelstrom", "Light That Burns the Sky", "G-Max Drum Solo", "G-Max Hydrosnipe", "G-Max Fireball"].includes(move.name) && defAbility !== "Shadow Shield")
-		defAbility = ""; //works as a mold breaker
+		if (defender.item === "Ability Shield") {
+			description.defenderItem = defender.item;
+		} else {
+			defAbility = "";
+			description.attackerAbility = attacker.ability;
+		}
+	} else if (["Moongeist Beam", "Sunsteel Strike", "Searing Sunraze Smash", "Menacing Moonraze Maelstrom", "Light That Burns the Sky", "G-Max Drum Solo", "G-Max Hydrosnipe", "G-Max Fireball"].includes(move.name) && defAbility !== "Shadow Shield") {
+		if (defender.item === "Ability Shield") {
+			description.defenderItem = defender.item;
+		} else {
+			defAbility = "";
+		}
+	}
 
 	var isCritical = move.isCrit && ["Battle Armor", "Shell Armor"].indexOf(defAbility) === -1;
 
@@ -245,6 +254,9 @@ function getDamageResult(attacker, defender, move, field) {
 	}
 	if (move.name === "Synchronoise" &&
             [defender.type1, defender.type2].indexOf(attacker.type1) === -1 && [defender.type1, defender.type2].indexOf(attacker.type2) === -1) {
+		return {"damage": [0], "description": buildDescription(description)};
+	}
+	if (move.name === "Steel Roller" && !field.terrain) {
 		return {"damage": [0], "description": buildDescription(description)};
 	}
 
@@ -394,9 +406,8 @@ function getDamageResult(attacker, defender, move, field) {
 
 	var bpMods = [];
 	if (attacker.ability === "Technician" && basePower <= 60 ||
-            attacker.ability === "Flare Boost" && attacker.status === "Burned" && move.category === "Special" ||
-            attacker.ability === "Toxic Boost" && (attacker.status === "Poisoned" || attacker.status === "Badly Poisoned") &&
-                    move.category === "Physical") {
+		attacker.ability === "Flare Boost" && attacker.status === "Burned" && move.category === "Special" ||
+		attacker.ability === "Toxic Boost" && (attacker.status === "Poisoned" || attacker.status === "Badly Poisoned") && move.category === "Physical") {
 		bpMods.push(0x1800);
 		description.attackerAbility = attacker.ability;
 	} else if (attacker.ability === "Analytic" && turnOrder !== "FIRST") {
@@ -458,14 +469,14 @@ function getDamageResult(attacker, defender, move, field) {
 		bpMods.push(0x1333);
 		description.attackerItem = attacker.item;
 	} else if (attacker.item === "Muscle Band" && move.category === "Physical" ||
-            attacker.item === "Wise Glasses" && move.category === "Special" ||
-            attacker.item === "Punching Glove" && move.isPunch) {
+		attacker.item === "Wise Glasses" && move.category === "Special" ||
+		attacker.item === "Punching Glove" && move.isPunch) {
 		bpMods.push(0x1199);
 		description.attackerItem = attacker.item;
-	} else if ((attacker.item === "Adamant Orb" && attacker.name === "Dialga" ||
-            attacker.item === "Lustrous Orb" && attacker.name === "Palkia" ||
-            attacker.item === "Griseous Orb" && attacker.name === "Giratina-O") &&
-            (move.type === attacker.type1 || move.type === attacker.type2)) {
+	} else if ((move.type === attacker.type1 || move.type === attacker.type2) && (
+		attacker.item === "Adamant Orb" && attacker.name === "Dialga" ||
+		attacker.item === "Lustrous Orb" && attacker.name === "Palkia" ||
+		attacker.item === "Griseous Orb" && attacker.name === "Giratina-O")) {
 		bpMods.push(0x1333);
 		description.attackerItem = attacker.item;
 	} else if (attacker.item === move.type + " Gem") {
@@ -474,8 +485,8 @@ function getDamageResult(attacker, defender, move, field) {
 	}
 
 	if (move.name === "Facade" && ["Burned", "Paralyzed", "Poisoned", "Badly Poisoned"].includes(attacker.status) ||
-            move.name === "Brine" && defender.curHP <= defender.maxHP / 2 ||
-            (move.name === "Venoshock" || move.name === "Barb Barrage") && (defender.status === "Poisoned" || defender.status === "Badly Poisoned")) {
+		move.name === "Brine" && defender.curHP <= defender.maxHP / 2 ||
+		(move.name === "Venoshock" || move.name === "Barb Barrage") && (defender.status === "Poisoned" || defender.status === "Badly Poisoned")) {
 		bpMods.push(0x2000);
 		description.moveBP = move.bp * 2;
 	} else if ((move.name === "Solar Beam" || move.name == "SolarBeam") && ["Rain", "Sand", "Hail", "Heavy Rain", "Snow"].includes(field.weather)) {
@@ -483,16 +494,16 @@ function getDamageResult(attacker, defender, move, field) {
 		description.moveBP = move.bp / 2;
 		description.weather = field.weather;
 	} else if (gen >= 6 && gen != 8 && move.name === "Knock Off" && !((defender.item === "") ||
-            (defender.name === "Giratina-O" && defender.item === "Griseous Orb") ||
-           (defender.item.includes("Memory")) ||
-           (defender.name.includes("Arceus") && defender.item.includes("Plate")) ||
-           (defender.item.includes(" Z")))) {
+		(defender.name === "Giratina-O" && defender.item === "Griseous Orb") ||
+		(defender.item.includes("Memory")) ||
+		(defender.name.includes("Arceus") && defender.item.includes("Plate")) ||
+		(defender.item.includes(" Z")))) {
 		bpMods.push(0x1800);
 		description.moveBP = move.bp * 1.5;
 	} else if (gen === 8 && move.name === "Knock Off" && !((defender.item === "") ||
-            (defender.name === "Giratina-O" && defender.item === "Griseous Orb") ||
-           (defender.item.includes("Memory")) ||
-           (defender.item.includes(" Z")))) {
+		(defender.name === "Giratina-O" && defender.item === "Griseous Orb") ||
+		(defender.item.includes("Memory")) ||
+		(defender.item.includes(" Z")))) {
 		bpMods.push(0x1800);
 		description.moveBP = move.bp * 1.5;
 	} else if (["Breakneck Blitz", "Bloom Doom", "Inferno Overdrive", "Hydro Vortex", "Gigavolt Havoc", "Subzero Slammer", "Supersonic Skystrike",
@@ -558,9 +569,32 @@ function getDamageResult(attacker, defender, move, field) {
 		}
 	}
 
+	var fainted = parseInt(field.faintedCount);
+	if (attacker.ability === "Supreme Overlord" && fainted > 0) {
+		// modifies the base power https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9421520
+		var multiplier;
+		switch (fainted) {
+			case 1:
+				multiplier = 1.1;
+				break;
+			case 2:
+				multiplier = 1.2;
+				break;
+			case 3:
+				multiplier = 1.3;
+				break;
+			case 4:
+				multiplier = 1.4;
+				break;
+			default:
+				multiplier = 1.5;
+		}
+		bpMods.push(Math.ceil(0x1000 * multiplier));
+		description.attackerAbility = attacker.ability + " (" + multiplier + "x BP)";
+	}
+
 	basePower = Math.max(1, pokeRound((basePower * chainMods(bpMods)) / 4096));
-	if (gen == 6) basePower = attacker.isChild ? basePower / 2 : basePower;
-	else if (gen >= 7) basePower = attacker.isChild ? basePower / 4 : basePower;
+	basePower = attacker.isChild ? basePower / (gen >= 7 ? 4 : 2) : basePower;
 
 	////////////////////////////////
 	////////// (SP)ATTACK //////////
@@ -591,7 +625,9 @@ function getDamageResult(attacker, defender, move, field) {
 	}
 
 	var atMods = [];
-	if (defAbility === "Thick Fat" && (move.type === "Fire" || move.type === "Ice") || defAbility === "Water Bubble" && move.type === "Fire" || defAbility === "Purifying Salt" && move.type === "Ghost") {
+	if (defAbility === "Thick Fat" && (move.type === "Fire" || move.type === "Ice") ||
+		defAbility === "Water Bubble" && move.type === "Fire" ||
+		defAbility === "Purifying Salt" && move.type === "Ghost") {
 		atMods.push(0x800);
 		description.defenderAbility = defAbility;
 	}
@@ -601,26 +637,26 @@ function getDamageResult(attacker, defender, move, field) {
 	}
 
 	if (attacker.ability === "Guts" && attacker.status !== "Healthy" && move.category === "Physical" ||
-            attacker.ability === "Overgrow" && attacker.curHP <= attacker.maxHP / 3 && move.type === "Grass" ||
-            attacker.ability === "Blaze" && attacker.curHP <= attacker.maxHP / 3 && move.type === "Fire" ||
-            attacker.ability === "Torrent" && attacker.curHP <= attacker.maxHP / 3 && move.type === "Water" ||
-            attacker.ability === "Swarm" && attacker.curHP <= attacker.maxHP / 3 && move.type === "Bug") {
+		attacker.ability === "Overgrow" && attacker.curHP <= attacker.maxHP / 3 && move.type === "Grass" ||
+		attacker.ability === "Blaze" && attacker.curHP <= attacker.maxHP / 3 && move.type === "Fire" ||
+		attacker.ability === "Torrent" && attacker.curHP <= attacker.maxHP / 3 && move.type === "Water" ||
+		attacker.ability === "Swarm" && attacker.curHP <= attacker.maxHP / 3 && move.type === "Bug") {
 		atMods.push(0x1800);
 		description.attackerAbility = attacker.ability;
 	} else if (attacker.ability === "Flash Fire (activated)" && move.type === "Fire") {
 		atMods.push(0x1800);
 		description.attackerAbility = "Flash Fire";
 	} else if (attacker.ability === "Solar Power" && field.weather.indexOf("Sun") > -1 && move.category === "Special" ||
-            attacker.ability === "Flower Gift" && field.weather.indexOf("Sun") > -1 && move.category === "Physical") {
+		attacker.ability === "Flower Gift" && field.weather.indexOf("Sun") > -1 && move.category === "Physical") {
 		atMods.push(0x1800);
 		description.attackerAbility = attacker.ability;
 		description.weather = field.weather;
 	} else if (attacker.ability === "Defeatist" && attacker.curHP <= attacker.maxHP / 2 ||
-            attacker.ability === "Slow Start" && move.category === "Physical") {
+		attacker.ability === "Slow Start" && move.category === "Physical") {
 		atMods.push(0x800);
 		description.attackerAbility = attacker.ability;
 	} else if (attacker.ability === "Water Bubble" && move.type === "Water" ||
-        (attacker.ability === "Huge Power" || attacker.ability === "Pure Power") && move.category === "Physical") {
+		(attacker.ability === "Huge Power" || attacker.ability === "Pure Power") && move.category === "Physical") {
 		atMods.push(0x2000);
 		description.attackerAbility = attacker.ability;
 	} else if (attacker.ability === "Gorilla Tactics" && move.category === "Physical" && !attacker.isDynamax) {
@@ -629,29 +665,27 @@ function getDamageResult(attacker, defender, move, field) {
 	}
 
 	if (attacker.item === "Thick Club" && (attacker.name === "Cubone" || attacker.name === "Marowak" || attacker.name === "Marowak-Alola") && move.category === "Physical" ||
-            attacker.item === "Deep Sea Tooth" && attacker.name === "Clamperl" && move.category === "Special" ||
-            attacker.item === "Light Ball" && attacker.name === "Pikachu" && !move.isZ) {
+		attacker.item === "Deep Sea Tooth" && attacker.name === "Clamperl" && move.category === "Special" ||
+		attacker.item === "Light Ball" && attacker.name === "Pikachu" && !move.isZ) {
 		atMods.push(0x2000);
 		description.attackerItem = attacker.item;
 	} else if (attacker.item === "Soul Dew" && (attacker.name === "Latios" || attacker.name === "Latias") && move.category === "Special" ||
-            attacker.item === "Choice Band" && (move.category === "Physical" || move.name === "Body Press") ||
-            attacker.item === "Choice Specs" && move.category === "Special" && !move.isZ) {
+		attacker.item === "Choice Band" && (move.category === "Physical" || move.name === "Body Press") ||
+		attacker.item === "Choice Specs" && move.category === "Special" && !move.isZ) {
 		atMods.push(0x1800);
 		description.attackerItem = attacker.item;
 	}
-
-	var attackerProtoQuark = checkProtoQuarkHighest(attacker, field.weather, field.terrain);
+	
 	if ((attacker.ability === "Hadron Engine" && field.terrain === "Electric" && move.category === "Special") ||
-		(attacker.ability === "Orichalcum Pulse" && field.weather.indexOf("Sun") > -1 && move.category === "Physical") ||
-		(attackerProtoQuark === "Atk" && move.category === "Physical") ||
-		(attackerProtoQuark === "SpA" && move.category === "Special")) {
-		atMods.push(0x14CD); // as of writing, Smogon and just Smogon says 1.3x
+		(attacker.ability === "Orichalcum Pulse" && field.weather.indexOf("Sun") > -1 && move.category === "Physical")) {
+		atMods.push(0x1555); // https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9423025
 		description.attackerAbility = attacker.ability;
 	}
-	var fainted = parseInt(field.faintedCount);
-	if (attacker.ability === "Supreme Overlord" && fainted > 0) {
-		atMods.push(0x1199 + 0x199 * fainted); // if at least 1 is fainted, then an additional 10% is added
-		description.attackerAbility = attacker.ability + " (1." + (fainted + 1) + "x Atk)";
+	var attackerProtoQuark = checkProtoQuarkHighest(attacker, field.weather, field.terrain);
+	if ((attackerProtoQuark === "Atk" && move.category === "Physical") ||
+		(attackerProtoQuark === "SpA" && move.category === "Special")) {
+		atMods.push(0x14CD); // https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9423025
+		description.attackerAbility = attacker.ability;
 	}
 	if ((field.isRuinTablets && move.category === "Physical") || (field.isRuinVessel && move.category === "Special")) {
 		atMods.push(0xC00);
@@ -704,14 +738,14 @@ function getDamageResult(attacker, defender, move, field) {
 		description.defenderItem = defender.item;
 	}
 
-	if ((field.isRuinSword && move.category === "Physical") || (field.isRuinBeads && move.category === "Special")) {
-		dfMods.push(0xC00);
-		description.isRuinDef = true;
-	}
 	var defenderProtoQuark = checkProtoQuarkHighest(defender, field.weather, field.terrain);
 	if ((defenderProtoQuark === "Def" && move.category === "Physical") || (defenderProtoQuark === "SpD" && move.category === "Special")) {
 		dfMods.push(0x14CD);
 		description.defenderAbility = defAbility;
+	}
+	if ((field.isRuinSword && move.category === "Physical") || (field.isRuinBeads && move.category === "Special")) {
+		dfMods.push(0xC00);
+		description.isRuinDef = true;
 	}
 
 	defense = Math.max(1, pokeRound(defense * chainMods(dfMods) / 0x1000));
@@ -774,10 +808,11 @@ function getDamageResult(attacker, defender, move, field) {
 	var applyBurn = attacker.status === "Burned" && move.category === "Physical" && attacker.ability !== "Guts" && !move.ignoresBurn;
 	description.isBurned = applyBurn;
 	var finalMods = [];
-	if (field.isReflect && move.category === "Physical" && !isCritical) {
+	var ignoresScreens = isCritical || ["Brick Break", "Psychic Fangs", "Raging Bull"].includes(move.name);
+	if (field.isReflect && move.category === "Physical" && !ignoresScreens) {
 		finalMods.push(field.format !== "Singles" ? 0xA8F : 0x800);
 		description.isReflect = true;
-	} else if (field.isLightScreen && move.category === "Special" && !isCritical) {
+	} else if (field.isLightScreen && move.category === "Special" && !ignoresScreens) {
 		finalMods.push(field.format !== "Singles" ? 0xA8F : 0x800);
 		description.isLightScreen = true;
 	}
@@ -837,7 +872,7 @@ function getDamageResult(attacker, defender, move, field) {
 		description.isQuarteredByProtect = true;
 	}
 	if (typeEffectiveness > 1 && (move.name === "Collision Course" || move.name === "Electro Drift")) {
-		finalMods.push(0x14CD);
+		finalMods.push(0x1555); // https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9423025
 	}
 	var finalMod = chainMods(finalMods);
 
@@ -1048,6 +1083,7 @@ function getFinalSpeed(pokemon, weather, terrain) {
 	} else if (pokemon.item === "Macho Brace" || pokemon.item === "Iron Ball") {
 		speed = Math.floor(speed / 2);
 	}
+	
 	if (pokemon.ability === "Chlorophyll" && weather.indexOf("Sun") > -1 ||
             pokemon.ability === "Sand Rush" && weather === "Sand" ||
             pokemon.ability === "Swift Swim" && weather.indexOf("Rain") > -1 ||

--- a/_scripts/export.js
+++ b/_scripts/export.js
@@ -56,11 +56,19 @@ function exportToPsFormat(pokeInfo) {
 	var evsAlert = false;
 	var name = pokemon.name;
 	if (name.indexOf("Mega ") != -1) {
-		var speciesName = name.substring(0, name.indexOf("Mega") - 1) + name.substring(name.indexOf("Mega") + 4, name.length);
-		if ((speciesName.indexOf(" X") == speciesName.length - 2) || (speciesName.indexOf(" Y") == speciesName.length - 2)) {
-			speciesName = speciesName.substring(0, speciesName.length - 2);
+		var speciesName = name.substring(name.indexOf("Mega ") + 5, name.length);
+		if (speciesName.indexOf(" X") == speciesName.length - 2) {
+			speciesName = speciesName.substring(0, speciesName.length - 2) + "-Mega-X";
 		}
-		pokemon.item = MEGA_STONE_LOOKUP[name];
+		else if (speciesName.indexOf(" Y") == speciesName.length - 2) {
+			speciesName = speciesName.substring(0, speciesName.length - 2) + "-Mega-Y";
+		}
+		else {
+			speciesName += "-Mega";
+		}
+		if (speciesName !== "Rayquaza-Mega") {
+			pokemon.item = MEGA_STONE_LOOKUP[name];
+		}
 	} else if (name.indexOf("-Blade") != -1) {
 		var speciesName = name.substring(0, name.indexOf("-")) + name.substring(name.indexOf("-") + 6, name.length);
 	} else if (name.indexOf("-Both") != -1) {

--- a/_scripts/move_data.js
+++ b/_scripts/move_data.js
@@ -68,6 +68,7 @@ var MOVES_RBY = {
 		"bp": 65,
 		"type": "Water",
 		"category": "Special",
+		"hasSecondaryEffect": true,
 		"acc": 100
 	},
 	"Clamp": {
@@ -148,7 +149,8 @@ var MOVES_RBY = {
 		"bp": 60,
 		"type": "Dragon",
 		"category": "Special",
-		"hasSecondaryEffect": true
+		"hasSecondaryEffect": true,
+		"acc": 100
 	},
 	"Dream Eater": {
 		"bp": 100,
@@ -370,6 +372,13 @@ var MOVES_RBY = {
 		"percentHealed": 0.5,
 		"acc": 100
 	},
+	"Mega Kick": {
+		"bp": 120,
+		"type": "Normal",
+		"category": "Physical",
+		"makesContact": true,
+		"acc": 75
+	},
 	"Minimize": {
 		"bp": 0,
 		"type": "Normal"
@@ -527,6 +536,7 @@ var MOVES_RBY = {
 	"Sludge": {
 		"bp": 65,
 		"type": "Poison",
+		"hasSecondaryEffect": true,
 		"acc": 100
 	},
 	"Soft-Boiled": {
@@ -670,12 +680,14 @@ var MOVES_RBY = {
 		"bp": 80,
 		"type": "Normal",
 		"category": "Special",
+		"hasSecondaryEffect": true,
 		"acc": 100
 	},
 	"Twineedle": {
 		"bp": 25,
 		"type": "Bug",
 		"isTwoHit": true,
+		"hasSecondaryEffect": true,
 		"acc": 100
 	},
 	"Waterfall": {
@@ -1052,7 +1064,8 @@ var MOVES_GSC = $.extend(true, {}, MOVES_RBY, {
 		"bp": 20,
 		"type": "Ground",
 		"category": "Special",
-		"hasSecondaryEffect": true
+		"hasSecondaryEffect": true,
+		"acc": 100
 	},
 	"Nightmare": {
 		"bp": 0,
@@ -1063,7 +1076,8 @@ var MOVES_GSC = $.extend(true, {}, MOVES_RBY, {
 		"type": "Water",
 		"category": "Special",
 		"acc": 85,
-		"hasSecondaryEffect": true
+		"hasSecondaryEffect": true,
+		"acc": 85
 	},
 	"Pain Split": {
 		"bp": 0,
@@ -1097,6 +1111,7 @@ var MOVES_GSC = $.extend(true, {}, MOVES_RBY, {
 		"type": "Normal",
 		"category": "Physical",
 		"makesContact": true,
+		"hasSecondaryEffect": true,
 		"acc": 100
 	},
 	"Razor Leaf": {"alwaysCrit": false},
@@ -3143,6 +3158,7 @@ var MOVES_BW = $.extend(true, {}, MOVES_DPP, {
 		"bp": 30,
 		"type": "Bug",
 		"category": "Special",
+		"hasSecondaryEffect": true,
 		"isSpread": true,
 		"acc": 100
 	},
@@ -3791,6 +3807,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
 		"category": "Special",
 		"isSound": true,
 		"isSpread": true,
+		"hasSecondaryEffect": true,
 		"isZ": true
 	},
 	"Clear Smog": {"zp": 100},
@@ -4440,6 +4457,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
 		"bp": 175,
 		"type": "Electric",
 		"category": "Special",
+		"hasSecondaryEffect": true,
 		"isZ": true
 	},
 	"Stomp": {"zp": 120},
@@ -4509,6 +4527,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
 		"type": "Dark",
 		"category": "Physical",
 		"makesContact": true,
+		"hasSecondaryEffect": true,
 		"zp": 160,
 		"acc": 100
 	},
@@ -4689,167 +4708,204 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"hasSecondaryEffect": true,
 		"acc": 100
 	},
-	"Mega Kick": {
-		"bp": 120,
-		"acc": 75,
-		"type": "Normal",
-		"category": "Physical",
-		"makesContact": true,
-	},
 	"Heat Crash": {
 		"bp": 1,
 		"acc": 100,
 		"type": "Fire",
 		"category": "Physical",
-		"makesContact": true
+		"makesContact": true,
+		"acc": 100
 	},
 	"Dynamax Cannon": {
 		"bp": 100,
 		"type": "Dragon",
 		"category": "Special",
+		"acc": 100
 	},
 	"Snipe Shot": {
 		"bp": 80,
 		"type": "Water",
 		"category": "Special",
+		"acc": 100
 	},
 	"Jaw Lock": {
 		"bp": 80,
 		"type": "Dark",
 		"category": "Physical",
+		"makesContact": true,
+		"acc": 100
 	},
 	"Dragon Darts": {
 		"bp": 50,
 		"type": "Dragon",
 		"category": "Physical",
-		"isTwoHit": true
+		"isTwoHit": true,
+		"acc": 100
 	},
 	"Bolt Beak": {
 		"bp": 85,
 		"type": "Electric",
 		"category": "Physical",
+		"makesContact": true,
+		"acc": 100
 	},
 	"Bolt Beak (Doubled)": {
 		"bp": 170,
 		"type": "Electric",
 		"category": "Physical",
+		"makesContact": true,
+		"acc": 100
 	},
 	"Fishious Rend": {
 		"bp": 85,
 		"type": "Water",
 		"category": "Physical",
 		"isBite": true,
+		"makesContact": true,
+		"acc": 100
 	},
 	"Fishious Rend (Doubled)": {
 		"bp": 170,
 		"type": "Water",
 		"category": "Physical",
 		"isBite": true,
+		"makesContact": true,
+		"acc": 100
 	},
 	"Body Press": {
 		"bp": 80,
 		"type": "Fighting",
 		"makesContact": true,
 		"category": "Physical",
+		"acc": 100
 	},
 	"Drum Beating": {
 		"bp": 80,
 		"type": "Grass",
 		"category": "Physical",
+		"hasSecondaryEffect": true,
+		"acc": 100
 	},
 	"Snap Trap": {
 		"bp": 35,
 		"type": "Grass",
 		"category": "Physical",
+		"makesContact": true,
+		"acc": 100
 	},
 	"Pyro Ball": {
 		"bp": 120,
 		"type": "Fire",
 		"category": "Physical",
+		"hasSecondaryEffect": true,
+		"acc": 90
 	},
 	"Behemoth Blade": {
 		"bp": 100,
 		"type": "Steel",
 		"isSlicing": true,
 		"category": "Physical",
+		"makesContact": true,
+		"acc": 100
 	},
 	"Behemoth Bash": {
 		"bp": 100,
 		"type": "Steel",
 		"category": "Physical",
+		"makesContact": true,
+		"acc": 100
 	},
 	"Aura Wheel": {
 		"bp": 110,
 		"type": "Electric",
 		"category": "Physical",
-	},
-	"Aura Wheel (Electric)": {
-		"bp": 110,
-		"type": "Electric",
-		"category": "Physical",
+		"hasSecondaryEffect": true,
+		"acc": 100
 	},
 	"Aura Wheel (Dark)": {
 		"bp": 110,
 		"type": "Dark",
 		"category": "Physical",
+		"hasSecondaryEffect": true,
+		"acc": 100
 	},
 	"Breaking Swipe": {
 		"bp": 60,
 		"type": "Dragon",
 		"category": "Physical",
+		"hasSecondaryEffect": true,
+		"makesContact": true,
 		"isSpread": true,
+		"acc": 100
 	},
 	"Branch Poke": {
 		"bp": 40,
 		"type": "Grass",
 		"category": "Physical",
+		"makesContact": true,
+		"acc": 100
 	},
 	"Overdrive": {
 		"bp": 80,
 		"type": "Electric",
 		"category": "Special",
 		"isSound": true,
-		"isSpread": true
+		"isSpread": true,
+		"acc": 100
 	},
 	"Apple Acid": {
 		"bp": 80,
 		"type": "Grass",
 		"category": "Special",
+		"hasSecondaryEffect": true,
+		"acc": 100
 	},
 	"Grav Apple": {
 		"bp": 80,
 		"type": "Grass",
 		"category": "Physical",
+		"hasSecondaryEffect": true,
+		"acc": 100
 	},
 	"Spirit Break": {
 		"bp": 75,
 		"type": "Fairy",
 		"category": "Physical",
+		"hasSecondaryEffect": true,
+		"makesContact": true,
+		"acc": 100
 	},
 	"Strange Steam": {
 		"bp": 90,
 		"type": "Fairy",
 		"category": "Special",
+		"hasSecondaryEffect": true,
+		"acc": 95
 	},
 	"False Surrender": {
 		"bp": 80,
 		"type": "Dark",
 		"category": "Physical",
+		"makesContact": true,
+		"acc": 101
 	},
 	"Meteor Assault": {
 		"bp": 150,
 		"type": "Fighting",
 		"category": "Physical",
+		"acc": 100
 	},
 	"Eternabeam": {
 		"bp": 160,
 		"type": "Dragon",
 		"category": "Special",
+		"acc": 90
 	},
 	"Steel Beam": {
 		"bp": 140,
 		"type": "Steel",
 		"category": "Special",
+		"acc": 95
 	},
 	"Stuff Cheeks": {
 		"bp": 0,
@@ -4964,7 +5020,14 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"acc": 101
 	},
 	"Multi-Attack": {
-		"bp": 120,
+		"bp": 120
+	},
+	"Shell Side Arm": {
+		"bp": 90,
+		"type": "Poison",
+		"category": "Special",
+		"usesHighestAttackStat": true,
+		"acc": 100
 	},
 	"Terrain Pulse": {
 		"bp": 50,
@@ -4977,12 +5040,14 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"bp": 70,
 		"type": "Fire",
 		"category": "Special",
+		"hasSecondaryEffect": true,
 		"acc": 100
 	},
 	"Flip Turn": {
 		"bp": 60,
 		"type": "Water",
 		"category": "Physical",
+		"makesContact": true,
 		"acc": 100
 	},
 	"Rising Voltage": {
@@ -4995,6 +5060,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"bp": 70,
 		"type": "Grass",
 		"category": "Physical",
+		"makesContact": true,
 		"acc": 100
 	},
 	"Triple Axel": {
@@ -5016,6 +5082,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"bp": 40,
 		"type": "Flying",
 		"category": "Physical",
+		"makesContact": true,
 		"acc": 90,
 		"isTwoHit": true
 	},
@@ -5023,20 +5090,21 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"bp": 80,
 		"type": "Psychic",
 		"category": "Special",
-		"acc": 100,
+		"acc": 100
 	},
 	"Skitter Smack": {
 		"bp": 70,
 		"type": "Bug",
 		"category": "Physical",
 		"hasSecondaryEffect": true,
+		"makesContact": true,
 		"acc": 90
 	},
 	"Meteor Beam": {
 		"bp": 120,
 		"type": "Rock",
 		"category": "Special",
-		"acc": 90,
+		"acc": 90
 	},
 	"Poltergeist": {
 		"bp": 110,
@@ -5055,18 +5123,21 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"bp": 75,
 		"type": "Dark",
 		"category": "Physical",
+		"makesContact": true,
 		"acc": 100
 	},
 	"Lash Out (Doubled)": {
 		"bp": 150,
 		"type": "Dark",
 		"category": "Physical",
+		"makesContact": true,
 		"acc": 100
 	},
 	"Steel Roller": {
 		"bp": 130,
 		"type": "Steel",
 		"category": "Physical",
+		"makesContact": true,
 		"acc": 100
 	},
 	"Misty Explosion": {
@@ -5080,6 +5151,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"bp": 25,
 		"type": "Water",
 		"category": "Physical",
+		"makesContact": true,
 		"acc": 100,
 		"alwaysCrit": true
 	},
@@ -5087,6 +5159,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"bp": 80,
 		"type": "Dark",
 		"category": "Physical",
+		"makesContact": true,
 		"acc": 100,
 		"alwaysCrit": true
 	},
@@ -5106,6 +5179,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"bp": 80,
 		"type": "Psychic",
 		"category": "Special",
+		"hasSecondaryEffect": true,
 		"acc": 100
 	},
 	"Freezing Glare": {
@@ -5128,6 +5202,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"type": "Fighting",
 		"category": "Physical",
 		"hasSecondaryEffect": true,
+		"makesContact": true,
 		"acc": 100
 	},
 	"Glacial Lance": {
@@ -5158,6 +5233,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"acc": 100
 	}
 });
+
 var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 	"Aqua Cutter": {
 		"bp": 70,
@@ -5171,7 +5247,7 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 		"type": "Water",
 		"category": "Physical",
 		"makesContact": true,
-		"hasSecondaryEffect": true,
+		"hasSecondaryEffect": true, // No actual effect, but is affected by Sheer Force
 		"acc": 100
 	},
 	"Armor Cannon": {
@@ -5232,7 +5308,8 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 	},
 	"Comeuppance": {
 		"bp": 0,
-		"type": "Dark"
+		"type": "Dark",
+		"makesContact": true
 	},
 	"Doodle": {
 		"bp": 0,
@@ -5297,6 +5374,7 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 		"category": "Physical",
 		"makesContact": true,
 		"isPunch": true,
+		"hasSecondaryEffect": true,
 		"acc": 100
 	},
 	"Kowtow Cleave": {
@@ -5353,6 +5431,7 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 		"bp": 80,
 		"type": "Dragon",
 		"category": "Physical",
+		"hasSecondaryEffect": true,
 		"acc": 100
 	},
 	"Population Bomb": {
@@ -5399,7 +5478,7 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 		"bp": 40,
 		"type": "Rock",
 		"category": "Physical",
-		"makesContact": true,
+		"hasSecondaryEffect": true,
 		"acc": 100
 	},
 	"Shed Tail": {
@@ -5440,6 +5519,7 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 		"type": "Fire",
 		"category": "Special",
 		"isSound": true,
+		"hasSecondaryEffect": true,
 		"acc": 100
 	},
 	"Trailblaze": {
@@ -5504,6 +5584,7 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 		"category": "Physical",
 		"isSlicing": true,
 		"makesContact": true,
+		"hasSecondaryEffect": true,
 		"acc": 100
 	},
 	"Chloroblast": {
@@ -5607,6 +5688,7 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 		"category": "Physical",
 		"isSlicing": true,
 		"makesContact": true,
+		"hasSecondaryEffect": true,
 		"acc": 90
 	},
 	"Take Heart": {

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -192,7 +192,7 @@ $(".percent-hp").keyup(function () {
 
 var lastAura = [false, false, false];
 $(".ability").bind("keyup change", function () {
-	autoSetMultiHits($(this).val(), $(this).closest(".poke-info"));
+	autoSetMultiHits($(this).closest(".poke-info"));
 	autoSetAura();
 	autoSetTerrain();
 });
@@ -312,6 +312,7 @@ function autosetWeather(ability, i) {
 
 $("#p1 .item").bind("keyup change", function () {
 	autosetStatus("#p1", $(this).val());
+	autoSetMultiHits($(this).closest(".poke-info"));
 });
 
 var lastManualStatus = {"#p1": "Healthy", "#p2": "Healthy"};
@@ -371,7 +372,9 @@ function autoSetRuin(i, side) {
 	}
 }
 
-function autoSetMultiHits(ability, pokeInfo) {
+function autoSetMultiHits(pokeInfo) {
+	var ability = pokeInfo.find(".ability").val();
+	var item = pokeInfo.find(".item").val();
 	for (var i = 1; i <= 4; i++) {
 		var moveInfo = pokeInfo.find(".move" + i);
 		var moveName = moveInfo.find("select.move-selector").val();
@@ -380,7 +383,7 @@ function autoSetMultiHits(ability, pokeInfo) {
 		} else if (moveName === "Triple Axel") {
 			moveInfo.children(".move-hits").val(3);
 		} else {
-			moveInfo.children(".move-hits").val(ability === "Skill Link" ? 5 : 3);
+			moveInfo.children(".move-hits").val(ability === "Skill Link" || item === "Loaded Dice" ? 5 : 3);
 		}
 	}
 }
@@ -409,7 +412,7 @@ $(".move-selector").change(function () {
 			moveHits.append($("<option></option>").attr("value", i).text(i + " hits"));
 		}
 		moveHits.show();
-		moveHits.val($(this).closest(".poke-info").find(".ability").val() === "Skill Link" || moveName === "Population Bomb" ? maxMultiHits : 3);
+		moveHits.val($(this).closest(".poke-info").find(".ability").val() === "Skill Link" || $(this).closest(".poke-info").find(".item").val() === "Loaded Dice" || moveName === "Population Bomb" ? maxMultiHits : 3);
 	} else {
 		moveHits.hide();
 	}
@@ -736,7 +739,7 @@ function Pokemon(pokeInfo) {
 				"category": defaultDetails.category,
 				"isCrit": !!defaultDetails.alwaysCrit,
 				"acc": defaultDetails.acc,
-				"hits": defaultDetails.maxMultiHits ? (this.ability === "Skill Link" || moveName === "Population Bomb" ? defaultDetails.maxMultiHits : 3) : defaultDetails.isThreeHit ? 3 : defaultDetails.isTwoHit ? 2 : 1,
+				"hits": defaultDetails.maxMultiHits ? (this.ability === "Skill Link" || this.item === "Loaded Dice" || moveName === "Population Bomb" ? defaultDetails.maxMultiHits : 3) : defaultDetails.isThreeHit ? 3 : defaultDetails.isTwoHit ? 2 : 1,
 				"usedTimes": 1
 			}));
 		}

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -467,7 +467,7 @@ $(".set-selector, #levelswitch").bind("change click keyup keydown", function () 
 		pokeObj.find(".max-level").val(10);
 		pokeObj.find(".max").prop("checked", false);
 		pokeObj.find(".max").change();
-		pokeObj.find(".tera-type").val("Normal");
+		pokeObj.find(".tera-type").val(pokemon.t1);
 		pokeObj.find(".tera").prop("checked", false);
 		pokeObj.find(".tera").change();
 		var moveObj;
@@ -486,7 +486,7 @@ $(".set-selector, #levelswitch").bind("change click keyup keydown", function () 
 			}
 			setSelectValueIfValid(pokeObj.find(".nature"), set.nature, "Hardy");
 			setSelectValueIfValid(abilityObj, set.ability ? set.ability : pokemon.ab, "");
-			setSelectValueIfValid(pokeObj.find(".tera-type"), set.teraType, "Normal");
+			setSelectValueIfValid(pokeObj.find(".tera-type"), set.teraType, pokemon.t1);
 			setSelectValueIfValid(itemObj, set.item, "");
 			for (i = 0; i < 4; i++) {
 				moveObj = pokeObj.find(".move" + (i + 1) + " select.move-selector");
@@ -505,7 +505,7 @@ $(".set-selector, #levelswitch").bind("change click keyup keydown", function () 
 			}
 			pokeObj.find(".nature").val("Hardy");
 			setSelectValueIfValid(abilityObj, pokemon.ab, "");
-			pokeObj.find(".tera-type").val("Normal");
+			pokeObj.find(".tera-type").val(pokemon.t1);
 			itemObj.val("");
 			for (i = 0; i < 4; i++) {
 				moveObj = pokeObj.find(".move" + (i + 1) + " select.move-selector");
@@ -539,12 +539,12 @@ function showFormes(formeObj, setName, pokemonName, pokemon) {
 		if (set.item) {
 		// Repurpose the previous filtering code to provide the "different default" logic
 			if (set.item.includes("ite") && !(set.item.includes("ite Y")) && !(set.item.includes("ite Herb")) ||
-        pokemonName === "Groudon" && set.item.includes("Red Orb") ||
-        pokemonName === "Kyogre" && set.item.includes("Blue Orb") ||
-        pokemonName === "Meloetta" && set.moves.includes("Relic Song") ||
-        pokemonName === "Rayquaza" && set.moves.includes("Dragon Ascent") ||
-        pokemonName === "Necrozma-Dusk Mane" && set.item.includes("Ultranecrozium Z") ||
-        pokemonName === "Necrozma-Dawn Wings" && set.item.includes("Ultranecrozium Z")) {
+				pokemonName === "Groudon" && set.item.includes("Red Orb") ||
+				pokemonName === "Kyogre" && set.item.includes("Blue Orb") ||
+				pokemonName === "Meloetta" && set.moves.includes("Relic Song") ||
+				pokemonName === "Rayquaza" && set.moves.includes("Dragon Ascent") ||
+				pokemonName === "Necrozma-Dusk Mane" && set.item.includes("Ultranecrozium Z") ||
+				pokemonName === "Necrozma-Dawn Wings" && set.item.includes("Ultranecrozium Z")) {
 				defaultForme = 1;
 			} else if (set.item.includes("ite Y")) {
 				defaultForme = 2;


### PR DESCRIPTION
- Full conformity/compatibility with Showdown's import/export format (mostly for Megas).
- The default Tera type is now the Pokemon's primary type when loading a blank set or when the Tera type was not supplied on set import.

- Small error fix for the sped-up mass calc. It should only have appeared if a user supplied Download as the ability.
- Proto/Quark now can affect the speed of the user's Pokemon in the mass calc's preview.

- Looked over move data correctness in move_data.js, namely double-checking the hasSecondaryEffect and makesContact flags. This was cross-referenced with dumped game data on the battle mechanics thread.
- Supreme Overlord's effect is now fully correct.
- Corrected Orichalcum Pulse/Hadron Engine's and Collision Course/Electro Drift's multiplier.
- Loaded Dice now auto-selects max hits like Skill Link does.
- Screens are now ignored by moves like Brick Break.