### PR TITLE
Tera boosts same-type weak moves

### DIFF
--- a/_scripts/damage.js
+++ b/_scripts/damage.js
@@ -206,6 +206,11 @@ function getDamageResult(attacker, defender, move, field) {
 	}
 	// there's still a few questions about how tera interacts with -ate, but leaving it alone for now (how does tera Normal work?)
 
+	if ((attacker.ability === "Gale Wings" && move.type === "Flying") ||
+		(move.name === "Grassy Glide" && field.terrain === "Grassy" && isGrounded(attacker, field.isGravity, attacker.ability === "Levitate"))) {
+		move.hasPriority = true;
+	}
+
 	var typeEffect1 = getMoveEffectiveness(move, defender.type1, attacker.ability === "Scrappy" || field.isForesight, field.isGravity);
 	var typeEffect2 = defender.type2 ? getMoveEffectiveness(move, defender.type2, attacker.ability === "Scrappy" || field.isForesight, field.isGravity) : 1;
 	var typeEffectiveness = typeEffect1 * typeEffect2;
@@ -256,7 +261,7 @@ function getDamageResult(attacker, defender, move, field) {
 	if (move.name === "Steel Roller" && !field.terrain) {
 		return {"damage": [0], "description": buildDescription(description)};
 	}
-	if (move.hasPriority || (move.name === "Grassy Glide" && field.terrain === "Grassy Terrain") || (move.type === "Flying" && attacker.ability === "Gale Wings")) {
+	if (move.hasPriority) {
 		if (field.terrain === "Psychic" && isGrounded(defender, field.isGravity, defAbility === "Levitate")) {
 			description.terrain = field.terrain;
 			return {"damage": [0], "description": buildDescription(description)};
@@ -599,6 +604,13 @@ function getDamageResult(attacker, defender, move, field) {
 
 	basePower = Math.max(1, pokeRound((basePower * chainMods(bpMods)) / 4096));
 	basePower = attacker.isChild ? basePower / (gen >= 7 ? 4 : 2) : basePower;
+	
+	if (attacker.isTerastal && move.type === attacker.type1 && basePower < 60 && !move.hasPriority && !move.maxMultiHits && !move.isTwoHit && !move.isThreeHit) {
+		// This effect is probably misplaced but should be close enough for the time being. Waiting on more research
+		basePower = 60; // https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9424394
+		description.moveBP = 60;
+
+	}
 
 	////////////////////////////////
 	////////// (SP)ATTACK //////////

--- a/_scripts/move_data.js
+++ b/_scripts/move_data.js
@@ -2132,6 +2132,7 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
 		"type": "Normal",
 		"category": "Physical",
 		"bypassesProtect": true,
+		"hasPriority": true,
 		"acc": 100
 	},
 	"Fire Fang": {
@@ -3630,6 +3631,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
 		"bp": 15,
 		"type": "Water",
 		"category": "Physical",
+		"hasPriority": true,
 		"maxMultiHits": 5,
 		"acc": 100
 	}
@@ -5247,7 +5249,7 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 		"type": "Water",
 		"category": "Physical",
 		"makesContact": true,
-		"hasSecondaryEffect": true, // No actual effect, but is affected by Sheer Force
+		"hasSecondaryEffect": true,
 		"acc": 100
 	},
 	"Armor Cannon": {
@@ -5374,7 +5376,8 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 		"category": "Physical",
 		"makesContact": true,
 		"isPunch": true,
-		"hasSecondaryEffect": true,
+		"hasSecondaryEffect": true, // No actual effect, but is affected by Sheer Force
+		"hasPriority": true,
 		"acc": 100
 	},
 	"Kowtow Cleave": {

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -617,19 +617,19 @@ function getTerrainEffects() {
 		var id = $(this).closest(".poke-info").prop("id");
 		var terrainValue = $("input:checkbox[name='terrain']:checked").val();
 		if (terrainValue === "Electric") {
-			$("#" + id).find("[value='Asleep']").prop("disabled", isGrounded($("#" + id)));
+			$("#" + id).find("[value='Asleep']").prop("disabled", isGroundedTerrain($("#" + id)));
 		} else if (terrainValue === "Misty") {
-			$("#" + id).find(".status").prop("disabled", isGrounded($("#" + id)));
+			$("#" + id).find(".status").prop("disabled", isGroundedTerrain($("#" + id)));
 		}
 		break;
 	default:
 		$("input:checkbox[name='terrain']").not(this).prop("checked", false);
 		if ($(this).prop("checked") && $(this).val() === "Electric") {
-			$("#p1").find("[value='Asleep']").prop("disabled", isGrounded($("#p1")));
-			$("#p2").find("[value='Asleep']").prop("disabled", isGrounded($("#p2")));
+			$("#p1").find("[value='Asleep']").prop("disabled", isGroundedTerrain($("#p1")));
+			$("#p2").find("[value='Asleep']").prop("disabled", isGroundedTerrain($("#p2")));
 		} else if ($(this).prop("checked") && $(this).val() === "Misty") {
-			$("#p1").find(".status").prop("disabled", isGrounded($("#p1")));
-			$("#p2").find(".status").prop("disabled", isGrounded($("#p2")));
+			$("#p1").find(".status").prop("disabled", isGroundedTerrain($("#p1")));
+			$("#p2").find(".status").prop("disabled", isGroundedTerrain($("#p2")));
 		} else {
 			$("#p1").find("[value='Asleep']").prop("disabled", false);
 			$("#p1").find(".status").prop("disabled", false);
@@ -640,7 +640,7 @@ function getTerrainEffects() {
 	}
 }
 
-function isGrounded(pokeInfo) {
+function isGroundedTerrain(pokeInfo) {
 	return $("#gravity").prop("checked") || pokeInfo.find(".type1").val() !== "Flying" && pokeInfo.find(".type2").val() !== "Flying" &&
             pokeInfo.find(".ability").val() !== "Levitate" && pokeInfo.find(".item").val() !== "Air Balloon";
 }

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -383,7 +383,7 @@ function autoSetMultiHits(pokeInfo) {
 		} else if (moveName === "Triple Axel") {
 			moveInfo.children(".move-hits").val(3);
 		} else {
-			moveInfo.children(".move-hits").val(ability === "Skill Link" || item === "Loaded Dice" ? 5 : 3);
+			moveInfo.children(".move-hits").val(ability === "Skill Link" ? 5 : (item === "Loaded Dice" ? 4 : 3));
 		}
 	}
 }
@@ -412,7 +412,7 @@ $(".move-selector").change(function () {
 			moveHits.append($("<option></option>").attr("value", i).text(i + " hits"));
 		}
 		moveHits.show();
-		moveHits.val($(this).closest(".poke-info").find(".ability").val() === "Skill Link" || $(this).closest(".poke-info").find(".item").val() === "Loaded Dice" || moveName === "Population Bomb" ? maxMultiHits : 3);
+		moveHits.val($(this).closest(".poke-info").find(".ability").val() === "Skill Link" || moveName === "Population Bomb" ? maxMultiHits : ($(this).closest(".poke-info").find(".item").val() === "Loaded Dice" ? 4 : 3));
 	} else {
 		moveHits.hide();
 	}
@@ -739,7 +739,7 @@ function Pokemon(pokeInfo) {
 				"category": defaultDetails.category,
 				"isCrit": !!defaultDetails.alwaysCrit,
 				"acc": defaultDetails.acc,
-				"hits": defaultDetails.maxMultiHits ? (this.ability === "Skill Link" || this.item === "Loaded Dice" || moveName === "Population Bomb" ? defaultDetails.maxMultiHits : 3) : defaultDetails.isThreeHit ? 3 : defaultDetails.isTwoHit ? 2 : 1,
+				"hits": defaultDetails.maxMultiHits ? (this.ability === "Skill Link" || moveName === "Population Bomb" ? defaultDetails.maxMultiHits : (this.item === "Loaded Dice" ? 4 : 3)) : defaultDetails.isThreeHit ? 3 : defaultDetails.isTwoHit ? 2 : 1,
 				"usedTimes": 1
 			}));
 		}


### PR DESCRIPTION
- The strange boosting of weak moves is now implemented
- Loaded Dice defaults multihits to 4, as discussed
- Since the calc has move priority flags now, Dazzling clones and Psychic Terrain account for them