### PR TITLE
More bugfixes and correctness updates

### DIFF
--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -703,7 +703,7 @@ function Pokemon(pokeInfo) {
 		} else if (pokemon.bs.hp === 1) {
 			this.maxHP = 1;
 		} else {
-			var HPIVs = 31;
+			var HPIVs = set.ivs && typeof set.ivs.hp !== "undefined" ? set.ivs.hp : 31;
 			this.maxHP = ~~((pokemon.bs.hp * 2 + HPIVs + ~~(this.HPEVs / 4)) * this.level / 100) + this.level + 10;
 		}
 		this.curHP = this.maxHP;


### PR DESCRIPTION
- Adaptability's interaction with Terastallization is now correct (2.25x, 2x, and 1.5x STAB with Adaptability depending on move type and tera type)
- Non-Terastallized Tera Blast now correctly receives -ate boosts and type changes.
- Minor edge case bugfix for terrain seeds raising stats.
- Meteor Beam now adds +1 to its user's SpA stats when calculating Meteor Beam. (should be useful for RS players with Gigalith-RS)
- The mass calc now correctly calculates sets' HP stats by using the sets' supplied IVs instead of 31. (I had noticed that RS 1vAll mass calcs were calculating too little percentage damage)