### PR TITLE
More bugfixes and correctness updates

### DIFF
--- a/_scripts/damage.js
+++ b/_scripts/damage.js
@@ -551,8 +551,13 @@ function getDamageResult(attacker, defender, move, field) {
 	} else if (attacker.ability === "Tough Claws" && move.makesContact) { //boosts by 1.3x for contact moves, apparently
 		bpMods.push(0x14CD);
 		description.attackerAbility = attacker.ability;
-	} else if (defAbility === "Fluffy" && move.makesContact && attacker.ability !== "Long Reach") {
-		bpMods.push(0x800);
+	} else if (defAbility === "Fluffy" && move.makesContact) {
+		if (attacker.ability !== "Long Reach") {
+			description.attackerAbility = attacker.ability;
+		} else {
+			bpMods.push(0x800);
+			description.defenderAbility = defAbility;
+		}
 	}
 
 	var isAttackerAura = attacker.ability === move.type + " Aura";

--- a/_scripts/damage.js
+++ b/_scripts/damage.js
@@ -85,10 +85,11 @@ function getDamageResult(attacker, defender, move, field) {
 		isQuarteredByProtect = true;
 	}
 
+	var attackerItem = attacker.item;
 	if (move.isMax) {
 		moveDescName = move.name + " (" + move.bp + " BP)";
-		if (attacker.item == "Choice Band" || attacker.item == "Choice Specs" || attacker.item == "Choice Scarf") {
-			attacker.item = "";
+		if (attackerItem == "Choice Band" || attackerItem == "Choice Specs" || attackerItem == "Choice Scarf") {
+			attackerItem = "";
 		}
 	}
 	var description = {
@@ -139,29 +140,29 @@ function getDamageResult(attacker, defender, move, field) {
 		break;
 
 	case "Judgment":
-		if (attacker.item.indexOf("Plate") !== -1) {
-			move.type = getItemBoostType(attacker.item);
+		if (attackerItem.indexOf("Plate") !== -1) {
+			move.type = getItemBoostType(attackerItem);
 		}
 		break;
 
 	case "Multi-Attack":
-		if (attacker.item.indexOf("Memory") !== -1) {
-			move.type = getMultiAttack(attacker.item);
+		if (attackerItem.indexOf("Memory") !== -1) {
+			move.type = getMultiAttack(attackerItem);
 		}
 		break;
 
 	case "Techno Blast":
-		if (attacker.item.indexOf("Drive") !== -1) {
-			move.type = getTechnoBlast(attacker.item);
+		if (attackerItem.indexOf("Drive") !== -1) {
+			move.type = getTechnoBlast(attackerItem);
 		}
 		break;
 
 	case "Natural Gift":
-		if (attacker.item.indexOf("Berry") !== -1) {
-			var gift = getNaturalGift(attacker.item);
+		if (attackerItem.indexOf("Berry") !== -1) {
+			var gift = getNaturalGift(attackerItem);
 			move.type = gift.t;
 			move.bp = gift.p;
-			description.attackerItem = attacker.item;
+			description.attackerItem = attackerItem;
 			description.moveBP = move.bp;
 			description.moveType = move.type;
 		}
@@ -352,7 +353,7 @@ function getDamageResult(attacker, defender, move, field) {
 		description.moveBP = basePower;
 		break;
 	case "Acrobatics":
-		basePower = attacker.item === "Flying Gem" || attacker.item === "" ? 110 : 55;
+		basePower = attackerItem === "Flying Gem" || attacker.item === "" ? 110 : 55;
 		description.moveBP = basePower;
 		break;
 	case "Wake-Up Slap":
@@ -368,9 +369,9 @@ function getDamageResult(attacker, defender, move, field) {
 		description.moveBP = basePower;
 		break;
 	case "Fling":
-		basePower = getFlingPower(attacker.item);
+		basePower = getFlingPower(attackerItem);
 		description.moveBP = basePower;
-		description.attackerItem = attacker.item;
+		description.attackerItem = attackerItem;
 		break;
 	case "Eruption":
 	case "Dragon Energy":
@@ -486,23 +487,24 @@ function getDamageResult(attacker, defender, move, field) {
 		description.isSteelySpirit = true;
 	}
 
-	if (getItemBoostType(attacker.item) === move.type) {
+	if (getItemBoostType(attackerItem) === move.type) {
 		bpMods.push(0x1333);
-		description.attackerItem = attacker.item;
-	} else if (attacker.item === "Muscle Band" && move.category === "Physical" ||
-		attacker.item === "Wise Glasses" && move.category === "Special" ||
-		attacker.item === "Punching Glove" && move.isPunch) {
+		description.attackerItem = attackerItem;
+	} else if (attackerItem === "Muscle Band" && move.category === "Physical" ||
+		attackerItem === "Wise Glasses" && move.category === "Special" ||
+		attackerItem === "Punching Glove" && move.isPunch) {
 		bpMods.push(0x1199);
-		description.attackerItem = attacker.item;
+		description.attackerItem = attackerItem;
 	} else if ((move.type === attacker.type1 || move.type === attacker.type2) && (
-		attacker.item === "Adamant Orb" && attacker.name === "Dialga" ||
-		attacker.item === "Lustrous Orb" && attacker.name === "Palkia" ||
-		attacker.item === "Griseous Orb" && attacker.name === "Giratina-O")) {
+		attackerItem === "Adamant Orb" && attacker.name === "Dialga" ||
+		attackerItem === "Lustrous Orb" && attacker.name === "Palkia" ||
+		attackerItem === "Griseous Orb" && attacker.name === "Giratina-O" ||
+		attackerItem === "Soul Dew" && gen >= 7 && (attacker.name === "Latios" || attacker.name === "Latias"))) {
 		bpMods.push(0x1333);
-		description.attackerItem = attacker.item;
-	} else if (attacker.item === move.type + " Gem") {
+		description.attackerItem = attackerItem;
+	} else if (attackerItem === move.type + " Gem") {
 		bpMods.push(gen >= 6 ? 0x14CD : 0x1800);
-		description.attackerItem = attacker.item;
+		description.attackerItem = attackerItem;
 	}
 
 	if (move.name === "Facade" && ["Burned", "Paralyzed", "Poisoned", "Badly Poisoned"].includes(attacker.status) ||
@@ -695,16 +697,16 @@ function getDamageResult(attacker, defender, move, field) {
 		description.attackerAbility = attacker.ability;
 	}
 
-	if (attacker.item === "Thick Club" && (attacker.name === "Cubone" || attacker.name === "Marowak" || attacker.name === "Marowak-Alola") && move.category === "Physical" ||
-		attacker.item === "Deep Sea Tooth" && attacker.name === "Clamperl" && move.category === "Special" ||
-		attacker.item === "Light Ball" && attacker.name === "Pikachu" && !move.isZ) {
+	if (attackerItem === "Thick Club" && (attacker.name === "Cubone" || attacker.name === "Marowak" || attacker.name === "Marowak-Alola") && move.category === "Physical" ||
+		attackerItem === "Deep Sea Tooth" && attacker.name === "Clamperl" && move.category === "Special" ||
+		attackerItem === "Light Ball" && attacker.name === "Pikachu" && !move.isZ) {
 		atMods.push(0x2000);
-		description.attackerItem = attacker.item;
-	} else if (attacker.item === "Soul Dew" && (attacker.name === "Latios" || attacker.name === "Latias") && move.category === "Special" ||
-		attacker.item === "Choice Band" && (move.category === "Physical" || move.name === "Body Press") ||
-		attacker.item === "Choice Specs" && move.category === "Special" && !move.isZ) {
+		description.attackerItem = attackerItem;
+	} else if (attackerItem === "Soul Dew" && gen < 7 && (attacker.name === "Latios" || attacker.name === "Latias") && move.category === "Special" ||
+		attackerItem === "Choice Band" && (move.category === "Physical" || move.name === "Body Press") ||
+		attackerItem === "Choice Specs" && move.category === "Special" && !move.isZ) {
 		atMods.push(0x1800);
-		description.attackerItem = attacker.item;
+		description.attackerItem = attackerItem;
 	}
 	
 	if ((attacker.ability === "Hadron Engine" && field.terrain === "Electric" && move.category === "Special") ||
@@ -768,7 +770,7 @@ function getDamageResult(attacker, defender, move, field) {
 
 	if (defender.item === "Deep Sea Scale" && defender.name === "Clamperl" && !hitsPhysical ||
             defender.item === "Metal Powder" && defender.name === "Ditto" ||
-            defender.item === "Soul Dew" && (defender.name === "Latios" || defender.name === "Latias") && !hitsPhysical ||
+            defender.item === "Soul Dew" && gen < 7 && (defender.name === "Latios" || defender.name === "Latias") && !hitsPhysical ||
             defender.item === "Assault Vest" && !hitsPhysical || defender.item === "Eviolite") {
 		dfMods.push(0x1800);
 		description.defenderItem = defender.item;
@@ -886,17 +888,17 @@ function getDamageResult(attacker, defender, move, field) {
 		finalMods.push(0xC00);
 		description.defenderAbility = defAbility;
 	}
-	if (attacker.item === "Expert Belt" && typeEffectiveness > 1 && !move.isZ) {
+	if (attackerItem === "Expert Belt" && typeEffectiveness > 1 && !move.isZ) {
 		finalMods.push(0x1333);
-		description.attackerItem = attacker.item;
-	} else if (attacker.item === "Life Orb" && !move.isZ) {
+		description.attackerItem = attackerItem;
+	} else if (attackerItem === "Life Orb" && !move.isZ) {
 		finalMods.push(0x14CC);
-		description.attackerItem = attacker.item;
+		description.attackerItem = attackerItem;
 	}
-	if (getBerryResistType(defender.item) === move.type && (typeEffectiveness > 1 || move.type === "Normal") &&
+	if (getBerryResistType(attackerItem) === move.type && (typeEffectiveness > 1 || move.type === "Normal") &&
             attacker.ability !== "Unnerve") {
 		finalMods.push(0x800);
-		description.defenderItem = defender.item;
+		description.defenderItem = attackerItem;
 	}
 	if (defAbility === "Fur Coat" && hitsPhysical) {
 		finalMods.push(0x800);
@@ -1113,7 +1115,7 @@ function getModifiedStat(stat, mod) {
 
 function getFinalSpeed(pokemon, weather, terrain) {
 	var speed = getModifiedStat(pokemon.rawStats[SP], pokemon.boosts[SP]);
-	if (pokemon.item === "Choice Scarf") {
+	if (pokemon.item === "Choice Scarf" && !pokemon.isDynamax) {
 		speed = Math.floor(speed * 1.5);
 	} else if (pokemon.item === "Macho Brace" || pokemon.item === "Iron Ball") {
 		speed = Math.floor(speed / 2);
@@ -1264,7 +1266,7 @@ function checkIntimidate(source, target) {
 			target.boosts[AT] = Math.min(6, target.boosts[AT] + 1);
 		} else if (target.ability === "Competitive") {
 			target.boosts[SA] = Math.min(6, target.boosts[SA] + 2);
-		} else if (["Clear Body", "White Smoke", "Hyper Cutter", "Full Metal Body", "Inner Focus"].indexOf(target.ability) !== -1 || target.item === "Clear Amulet") {
+		} else if (["Clear Body", "White Smoke", "Hyper Cutter", "Full Metal Body"].includes(target.ability) || (gen > 7 && ["Inner Focus", "Oblivious", "Scrappy", "Own Tempo"].includes(target.ability)) || target.item === "Clear Amulet") {
 			// no effect (going by how Adrenaline Orb and Defiant work, checking these should come second)
 		} else if (target.ability === "Simple") {
 			target.boosts[AT] = Math.max(-6, target.boosts[AT] - 2);

--- a/_scripts/damage.js
+++ b/_scripts/damage.js
@@ -320,7 +320,7 @@ function getDamageResult(attacker, defender, move, field) {
 		description.moveBP = basePower;
 		break;
 	case "Gyro Ball":
-		basePower = Math.min(150, Math.floor(25 * defender.stats[SP] / attacker.stats[SP]));
+		basePower = attacker.stats[SP] === 0 ? 1 : Math.min(150, Math.floor(25 * defender.stats[SP] / attacker.stats[SP]) + 1);
 		description.moveBP = basePower;
 		break;
 	case "Punishment":
@@ -550,7 +550,7 @@ function getDamageResult(attacker, defender, move, field) {
 		bpMods.push(0x1333);
 		description.attackerAbility = attacker.ability;
 	} else if (attacker.ability === "Mega Launcher" && move.isPulse ||
-            attacker.ability === "Strong Jaw" && move.isBite) {
+		attacker.ability === "Strong Jaw" && move.isBite) {
 		bpMods.push(0x1800);
 		description.attackerAbility = attacker.ability;
 	} else if (attacker.ability === "Tough Claws" && move.makesContact) { //boosts by 1.3x for contact moves, apparently

--- a/_scripts/damage.js
+++ b/_scripts/damage.js
@@ -99,6 +99,9 @@ function getDamageResult(attacker, defender, move, field) {
 		"isDynamax": defender.isDynamax
 	};
 	predictShellSideArm(attacker, defender, move);
+	if (attacker.ability === "Long Reach" || attackerItem === "Punching Glove") {
+		move.makesContact = false;
+	}
 	if (defender.isTerastal) {
 		description.defenderTera = "Tera " + defender.type1;
 	}
@@ -553,13 +556,6 @@ function getDamageResult(attacker, defender, move, field) {
 	} else if (attacker.ability === "Tough Claws" && move.makesContact) { //boosts by 1.3x for contact moves, apparently
 		bpMods.push(0x14CD);
 		description.attackerAbility = attacker.ability;
-	} else if (defAbility === "Fluffy" && move.makesContact) {
-		if (attacker.ability !== "Long Reach") {
-			description.attackerAbility = attacker.ability;
-		} else {
-			bpMods.push(0x800);
-			description.defenderAbility = defAbility;
-		}
 	}
 
 	var isAttackerAura = attacker.ability === move.type + " Aura";
@@ -662,10 +658,6 @@ function getDamageResult(attacker, defender, move, field) {
 		defAbility === "Water Bubble" && move.type === "Fire" ||
 		defAbility === "Purifying Salt" && move.type === "Ghost") {
 		atMods.push(0x800);
-		description.defenderAbility = defAbility;
-	}
-	if (defAbility === "Fluffy" && move.type === "Fire") {
-		atMods.push(0x2000);
 		description.defenderAbility = defAbility;
 	}
 
@@ -856,7 +848,7 @@ function getDamageResult(attacker, defender, move, field) {
 	if ((move.name === "Dynamax Cannon" || move.name === "Behemoth Blade" || move.name === "Behemoth Bash") && defender.isDynamax) {
 		finalMods.push(0x2000);
 	}
-	if ((defAbility === "Multiscale" || defAbility == "Shadow Shield") && defender.curHP === defender.maxHP) {
+	if (((defAbility === "Multiscale" || defAbility == "Shadow Shield") && defender.curHP === defender.maxHP) || (defAbility === "Fluffy" && move.makesContact)) {
 		finalMods.push(0x800);
 		description.defenderAbility = defAbility;
 	}
@@ -886,6 +878,10 @@ function getDamageResult(attacker, defender, move, field) {
 	}
 	if ((defAbility === "Solid Rock" || defAbility === "Filter" || defAbility === "Prism Armor") && typeEffectiveness > 1) {
 		finalMods.push(0xC00);
+		description.defenderAbility = defAbility;
+	}
+	if (defAbility === "Fluffy" && move.type === "Fire") {
+		finalMods.push(0x2000);
 		description.defenderAbility = defAbility;
 	}
 	if (attackerItem === "Expert Belt" && typeEffectiveness > 1 && !move.isZ) {

--- a/_scripts/export.js
+++ b/_scripts/export.js
@@ -132,7 +132,7 @@ function exportToPsFormat(pokeInfo) {
 
 	var movesArray = [];
 	for (i = 0; i < 4; i++) {
-		var moveName = pokemon.moves[i].name;
+		var moveName = pokemon.baseMoveNames[i];
 		if (moveName !== "(No Move)") {
 			finalText += "- " + moveName + "\n";
 		}
@@ -142,86 +142,6 @@ function exportToPsFormat(pokeInfo) {
 	if (evsAlert === true) {
 		alert("Exported Pokemon has " + evSum + " EVs and is therefore illegal. Exported set anyway.");
 	}
-	document.getElementById("customMon").innerHTML = finalText;
-
-	var copyText = document.getElementById("customMon");
-	copyText.select();
-	document.execCommand("Copy");
-}
-
-function exportToPsFormatLG(pokeInfo) {
-	var pokemon = new Pokemon(pokeInfo);
-	var finalText = "";
-	var avSum = 0;
-	var ivSum = 0;
-	var name = pokemon.name;
-	if (name.indexOf("Mega ") != -1) {
-		var speciesName = name.substring(0, name.indexOf("Mega") - 1) + name.substring(name.indexOf("Mega") + 4, name.length);
-	} else if (name.indexOf("-Blade") != -1) {
-		var speciesName = name.substring(0, name.indexOf("-")) + name.substring(name.indexOf("-") + 6, name.length);
-	} else if (name.indexOf("-Both") != -1) {
-		var speciesName = name.substring(0, name.indexOf("-")) + name.substring(name.indexOf("-") + 5, name.length);
-	} else if (name.indexOf("Primal ") != -1) {
-		var speciesName = name.substring(0, name.indexOf("Primal") - 1) + name.substring(name.indexOf("Primal") + 6, name.length);
-	} else {
-		var speciesName = name;
-	}
-
-	finalText = speciesName + "\n";
-	finalText += pokemon.nature && gen > 2 ? pokemon.nature + " Nature" + "\n" : "";
-	finalText += "EVs: ";
-	var AVs_Array = [];
-	if (pokemon.HPAVs && pokemon.HPAVs > 0) {
-		avSum += pokemon.HPAVs;
-		AVs_Array.push(pokemon.HPAVs + " HP");
-	}
-	for (stat in pokemon.avs) {
-		if (pokemon.avs[stat]) {
-			avSum += pokemon.avs[stat];
-			AVs_Array.push(pokemon.avs[stat] + " " + toSmogonStat(stat));
-		}
-	}
-
-	var ivArray = [];
-	var IVs_Array = [];
-	if (pokemon.HPIVs != -1) {
-		ivSum += pokemon.HPIVs;
-		//IVs_Array.push(pokemon.HPIVs + " HP");
-		if (pokemon.HPIVs != 31) {
-			ivArray.push(pokemon.HPIVs + " HP");
-		}
-	}
-	for (stat in pokemon.ivs) {
-		if (pokemon.ivs[stat]) {
-			ivSum += pokemon.ivs[stat];
-		}
-		if (pokemon.ivs[stat] < 31) {
-			ivArray.push(pokemon.ivs[stat] + " " + toSmogonStat(stat));
-		}
-	}
-
-	for (var i = 0; i < ivArray.length - 2; i++) {
-		IVs_Array.push(ivArray[i]);
-	}
-
-	finalText += serialize(AVs_Array, " / ");
-	finalText += "\n";
-
-	if (ivSum < 186) {
-		finalText += "IVs: ";
-		finalText += serialize(IVs_Array, " / ");
-		finalText += "\n";
-	}
-
-	var movesArray = [];
-	for (i = 0; i < 4; i++) {
-		var moveName = pokemon.moves[i].name;
-		if (moveName !== "(No Move)") {
-			finalText += "- " + moveName + "\n";
-		}
-	}
-	finalText = finalText.trim();
-
 	document.getElementById("customMon").innerHTML = finalText;
 
 	var copyText = document.getElementById("customMon");

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -63,7 +63,7 @@ $.fn.dataTableExt.oSort['damage48-desc'] = function (a, b) {
 };
 
 function performCalculations() {
-	var attacker, defender, setPokemon, setTier;
+	var attacker, defender, setPoke, setTier;
 	var selectedTier = getSelectedTier(); // selectedTier can be: All, 28, 40, Tower, RS, SM*, DM*.  *Singles and Doubles Master
 	var setOptions = getSetOptions();
 	var dataSet = [];
@@ -76,13 +76,13 @@ function performCalculations() {
 			continue;
 		}
 		
-		setPokemon = new Pokemon(setOptionsID);
-		setTier = setPokemon.tier;
-		if (selectedTier === setTier) { // setPokemon.tier can currently be: 28, 40, Tower, RS, SM, DM, SMDM
+		setPoke = new Pokemon(setOptionsID);
+		setTier = setPoke.tier;
+		if (selectedTier === setTier) { // setPoke.tier can currently be: 28, 40, Tower, RS, SM, DM, SMDM
 			// let set be calculated
 		}
 		else if (selectedTier === "All") {
-			var customDexSpecies = SETDEX_CUSTOM[setPokemon.name];
+			var customDexSpecies = SETDEX_CUSTOM[setPoke.name];
 			if (customDexSpecies !== undefined && customDexSpecies[setOptionsID.substring(setOptionsID.indexOf("(") + 1, setOptionsID.length - 1)]) {
 				continue;
 			}
@@ -97,10 +97,10 @@ function performCalculations() {
 
 		var field = new Field();
 		if (mode === "one-vs-all") {
-			defender = setPokemon;
+			defender = setPoke;
 			attacker = userPoke;
 		} else {
-			attacker = setPokemon;
+			attacker = setPoke;
 			defender = userPoke;
 		}
 		if (attacker.ability === "Rivalry") {

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -739,11 +739,12 @@ function Pokemon(pokeInfo) {
 				"category": defaultDetails.category,
 				"isCrit": !!defaultDetails.alwaysCrit,
 				"acc": defaultDetails.acc,
-				"hits": defaultDetails.maxMultiHits ? (this.ability === "Skill Link" || moveName === "Population Bomb" ? defaultDetails.maxMultiHits : (this.item === "Loaded Dice" ? 4 : 3)) : defaultDetails.isThreeHit ? 3 : defaultDetails.isTwoHit ? 2 : 1,
+				"hits": defaultDetails.maxMultiHits ? (this.ability === "Skill Link" || moveName === "Population Bomb" || moveName === "Triple Axel" ? defaultDetails.maxMultiHits : (this.item === "Loaded Dice" ? 4 : 3)) : defaultDetails.isThreeHit ? 3 : defaultDetails.isTwoHit ? 2 : 1,
 				"usedTimes": 1
 			}));
 		}
-		this.weight = pokemon.weight;
+		this.baseMoveNames = [this.moves[0].name, this.moves[1].name, this.moves[2].name, this.moves[3].name];
+		this.weight = pokemon.w;
 		this.tier = set.tier;
 	} else {
 		var setName = pokeInfo.find("input.set-selector").val();
@@ -784,11 +785,16 @@ function Pokemon(pokeInfo) {
 		this.item = pokeInfo.find(".item").val();
 		this.status = pokeInfo.find(".status").val();
 		this.toxicCounter = this.status === "Badly Poisoned" ? ~~pokeInfo.find(".toxic-counter").val() : 0;
+		var move1 = pokeInfo.find(".move1");
+		var move2 = pokeInfo.find(".move2");
+		var move3 = pokeInfo.find(".move3");
+		var move4 = pokeInfo.find(".move4");
+		this.baseMoveNames = [move1.find("select.move-selector").val(), move2.find("select.move-selector").val(), move3.find("select.move-selector").val(), move4.find("select.move-selector").val()];
 		this.moves = [
-			getMoveDetails(pokeInfo.find(".move1"), this.item, this.name),
-			getMoveDetails(pokeInfo.find(".move2"), this.item, this.name),
-			getMoveDetails(pokeInfo.find(".move3"), this.item, this.name),
-			getMoveDetails(pokeInfo.find(".move4"), this.item, this.name)
+			getMoveDetails(move1, this.item, this.name),
+			getMoveDetails(move2, this.item, this.name),
+			getMoveDetails(move3, this.item, this.name),
+			getMoveDetails(move4, this.item, this.name)
 		];
 		this.weight = +pokeInfo.find(".weight").val();
 	}


### PR DESCRIPTION
- Fixed weight-based moves not calculating correctly in the mass calc.
- Improved the set export so that the base moves are used. Z-moves and Max moves would export with their transformed names instead.
- Minor corrections to Soul Dew and Intimidate-blocking abilities.
- Choice items would be removed when calculating Max moves, meaning mixing Max moves with regular attacks could give incorrect results on the regular attacks.
- Punching Glove now correctly interacts with Fluffy and Tough Claws.
- Fluffy's modifiers now affect the final damage instead of the atk and BP.
- Gyro Ball's BP is now correct. Except when the BP was 150, it was always 1 BP less than it should have been.