### PR TITLE
Further optimize mass calc

### DIFF
--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -679,11 +679,11 @@ var stickyMoves = (function () {
 	};
 })();
 
-function Pokemon(pokeInfo) {
-	if (typeof pokeInfo === "string") { // in this case, pokeInfo is the id of an individual setOptions value whose moveset's tier matches the selected tier(s)
-		this.name = pokeInfo.substring(0, pokeInfo.indexOf(" ("));
-		var setName = pokeInfo.substring(pokeInfo.indexOf("(") + 1, pokeInfo.lastIndexOf(")"));
-		var pokemon = pokedex[this.name];
+function Pokemon(pokeInfo, setName) { // if passing a jquery object, just call this with 1 argument
+	if (typeof pokeInfo === "string") {
+		// this branch is used for the mass calc; pokeInfo is species name
+		this.name = pokeInfo;
+		var pokemon = pokedex[pokeInfo];
 		this.type1 = pokemon.t1;
 		this.type2 = pokemon.t2 && typeof pokemon.t2 !== "undefined" ? pokemon.t2 : "";
 		this.rawStats = [];
@@ -971,6 +971,9 @@ function Field() {
 	this.getWeather = function () {
 		return weather;
 	};
+	this.setWeather = function (newWeather) {
+		weather = newWeather;
+	};
 	this.clearWeather = function () {
 		weather = "";
 	};
@@ -1245,7 +1248,6 @@ function getSetOptions() {
 		}
 	}
 	var setOptions = [];
-	var idNum = 0;
 	for (var i = 0; i < pokeNames.length; i++) {
 		var pokeName = pokeNames[i];
 		setOptions.push({


### PR DESCRIPTION
This makes the mass calc about 40% faster. This puts total speed improvement for the mass calc at around 80% compared to when its code was first merged in.
For an attacker with 4 attacks in 1vAll mode, a mass calc takes around 1250ms.
In Allv1 mode, a mass calc takes around 1350ms.