### PR TITLE
Small improvements

### DIFF
--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -135,7 +135,7 @@ function performCalculations() {
 	var field = new Field();
 	var startingWeather = field.getWeather();
 	var counter = 0;
-	var setSpecies = Object.keys(setdex);
+	var setSpecies = Object.keys((gen == 3 && $("#autolevel-box").val() == 50) ? SETDEX_EM : setdex);
 	for (var i = 0; i < setSpecies.length; i++) {
 		var speciesName = setSpecies[i];
 		var setNames = Object.keys(setdex[speciesName]);

--- a/_scripts/move_data.js
+++ b/_scripts/move_data.js
@@ -1700,6 +1700,13 @@ var MOVES_ADV = $.extend(true, {}, MOVES_GSC, {
 		"type": "Normal"
 	},
 	"Revenge": {
+		"bp": 60,
+		"type": "Fighting",
+		"category": "Physical",
+		"makesContact": true,
+		"acc": 100
+	},
+	"Revenge (Doubled)": {
 		"bp": 120,
 		"type": "Fighting",
 		"category": "Physical",
@@ -4303,6 +4310,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
 		"acc": 100
 	},
 	"Revenge": {"zp": 120},
+	"Revenge (Doubled)": {"zp": 120},
 	"Reversal": {"zp": 160},
 	"Roar of Time": {"zp": 200},
 	"Rock Blast": {"isBullet": true, "zp": 140},
@@ -5711,6 +5719,7 @@ delete MOVES_SV["Nature Power"];
 delete MOVES_SV["Assist"];
 delete MOVES_SV["Magic Coat"];
 delete MOVES_SV["Revenge"];
+delete MOVES_SV["Revenge (Doubled)"];
 delete MOVES_SV["Refresh"];
 delete MOVES_SV["Grudge"];
 delete MOVES_SV["Snatch"];
@@ -5858,9 +5867,9 @@ delete MOVES_SV["Double Iron Bash"];
 delete MOVES_SV["Max Guard"];
 delete MOVES_SV["Octolock"];
 delete MOVES_SV["Bolt Beak"];
-delete MOVES_SV["Bolt Beak (doubled)"];
+delete MOVES_SV["Bolt Beak (Doubled)"];
 delete MOVES_SV["Fishious Rend"];
-delete MOVES_SV["Fishious Rend (doubled)"];
+delete MOVES_SV["Fishious Rend (Doubled)"];
 delete MOVES_SV["Max Flare"];
 delete MOVES_SV["Max Flutterby"];
 delete MOVES_SV["Max Lightning"];

--- a/_scripts/setdex_gen3_sets.js
+++ b/_scripts/setdex_gen3_sets.js
@@ -1348,7 +1348,7 @@ SETDEX_EM = {
       },
       "moves": [
         "Seismic Toss",
-        "Revenge",
+        "Revenge (Doubled)",
         "Rock Tomb",
         "Scary Face"
       ],
@@ -4173,7 +4173,7 @@ SETDEX_EM = {
         "sd": 255
       },
       "moves": [
-        "Revenge",
+        "Revenge (Doubled)",
         "Sludge Bomb",
         "Shadow Ball",
         "Destiny Bond"
@@ -5830,7 +5830,7 @@ SETDEX_EM = {
         "Submission",
         "Focus Energy",
         "Swords Dance",
-        "Revenge"
+        "Revenge (Doubled)"
       ],
       "nature": "Naughty",
       "item": "Black Belt"
@@ -9958,7 +9958,7 @@ SETDEX_EM = {
         "at": 255
       },
       "moves": [
-        "Revenge",
+        "Revenge (Doubled)",
         "Rock Slide",
         "Facade",
         "Counter"

--- a/_scripts/setdex_gen3_sets.js
+++ b/_scripts/setdex_gen3_sets.js
@@ -13079,36 +13079,6 @@ SETDEX_EM = {
       "item": "Chesto Berry",
       "tier": "50"
     },
-    "Articuno-5 (871)": {
-      "evs": {
-        "at": 255,
-        "sa": 255
-      },
-      "moves": [
-        "Blizzard",
-        "Double-Edge",
-        "Agility",
-        "Swagger"
-      ],
-      "nature": "Docile",
-      "item": "Focus Band",
-      "tier": "50"
-    },
-    "Articuno-6 (872)": {
-      "evs": {
-        "at": 255,
-        "sa": 255
-      },
-      "moves": [
-        "Ice Beam",
-        "Aerial Ace",
-        "Reflect",
-        "Rest"
-      ],
-      "nature": "Docile",
-      "item": "Chesto Berry",
-      "tier": "50"
-    },
     "Articuno (Brandon Gold)": {
       "evs": {
         "hp": 6,
@@ -13187,37 +13157,6 @@ SETDEX_EM = {
       "item": "Shell Bell",
       "tier": "50"
     },
-    "Zapdos-5 (873)": {
-      "evs": {
-        "at": 255,
-        "sa": 255
-      },
-      "moves": [
-        "Thunderbolt",
-        "Drill Peck",
-        "Double-Edge",
-        "Thunder Wave"
-      ],
-      "nature": "Docile",
-      "item": "Scope Lens",
-      "tier": "50"
-    },
-    "Zapdos-6 (874)": {
-      "evs": {
-        "at": 170,
-        "sa": 170,
-        "sp": 170
-      },
-      "moves": [
-        "Thunder",
-        "Drill Peck",
-        "Rain Dance",
-        "Double-Edge"
-      ],
-      "nature": "Docile",
-      "item": "Lum Berry",
-      "tier": "50"
-    },
     "Zapdos (Brandon Gold)": {
       "evs": {
         "hp": 6,
@@ -13292,36 +13231,6 @@ SETDEX_EM = {
         "Safeguard"
       ],
       "nature": "Quiet",
-      "item": "White Herb",
-      "tier": "50"
-    },
-    "Moltres-5 (875)": {
-      "evs": {
-        "sa": 255,
-        "sp": 255
-      },
-      "moves": [
-        "Overheat",
-        "Sunny Day",
-        "Swagger",
-        "Facade"
-      ],
-      "nature": "Docile",
-      "item": "White Herb",
-      "tier": "50"
-    },
-    "Moltres-6 (876)": {
-      "evs": {
-        "at": 255,
-        "sa": 255
-      },
-      "moves": [
-        "Overheat",
-        "Double-Edge",
-        "Aerial Ace",
-        "Steel Wing"
-      ],
-      "nature": "Docile",
       "item": "White Herb",
       "tier": "50"
     },
@@ -13402,36 +13311,6 @@ SETDEX_EM = {
       "item": "Lum Berry",
       "tier": "50"
     },
-    "Raikou-5 (877)": {
-      "evs": {
-        "sa": 255,
-        "sp": 255
-      },
-      "moves": [
-        "Thunderbolt",
-        "Double-Edge",
-        "Roar",
-        "Reflect"
-      ],
-      "nature": "Modest",
-      "item": "BrightPowder",
-      "tier": "50"
-    },
-    "Raikou-6 (878)": {
-      "evs": {
-        "hp": 255,
-        "df": 255
-      },
-      "moves": [
-        "Thunderbolt",
-        "Calm Mind",
-        "Substitute",
-        "Rest"
-      ],
-      "nature": "Modest",
-      "item": "Chesto Berry",
-      "tier": "50"
-    },
     "Raikou (Anabel Gold)": {
       "evs": {
         "hp": 158,
@@ -13507,36 +13386,6 @@ SETDEX_EM = {
       ],
       "nature": "Modest",
       "item": "King's Rock",
-      "tier": "50"
-    },
-    "Entei-5 (879)": {
-      "evs": {
-        "df": 255,
-        "sd": 255
-      },
-      "moves": [
-        "Fire Blast",
-        "Double-Edge",
-        "Endure",
-        "Reflect"
-      ],
-      "nature": "Docile",
-      "item": "Salac Berry",
-      "tier": "50"
-    },
-    "Entei-6 (880)": {
-      "evs": {
-        "df": 255,
-        "sd": 255
-      },
-      "moves": [
-        "Flamethrower",
-        "Calm Mind",
-        "Roar",
-        "Rest"
-      ],
-      "nature": "Modest",
-      "item": "Chesto Berry",
       "tier": "50"
     },
     "Entei (Anabel Silver)": {
@@ -14307,7 +14156,10 @@ SETDEX_EM = {
       "nature": "Modest",
       "item": "BrightPowder"
     }
-  },
+  }
+};
+
+SETDEX_EM_OPEN_LVL = {
   "Dragonite": {
     "Dragonite-1 (851)": {
       "evs": {
@@ -14618,6 +14470,200 @@ SETDEX_EM = {
       ],
       "nature": "Adamant",
       "item": "Lum Berry",
+      "tier": "50"
+    }
+  },
+  "Articuno": {
+    "Articuno-5 (871)": {
+      "evs": {
+        "at": 255,
+        "sa": 255
+      },
+      "moves": [
+        "Blizzard",
+        "Double-Edge",
+        "Agility",
+        "Swagger"
+      ],
+      "nature": "Docile",
+      "item": "Focus Band",
+      "tier": "50"
+    },
+    "Articuno-6 (872)": {
+      "evs": {
+        "at": 255,
+        "sa": 255
+      },
+      "moves": [
+        "Ice Beam",
+        "Aerial Ace",
+        "Reflect",
+        "Rest"
+      ],
+      "nature": "Docile",
+      "item": "Chesto Berry",
+      "tier": "50"
+    }
+  },
+  "Zapdos" : {
+    "Zapdos-5 (873)": {
+      "evs": {
+        "at": 255,
+        "sa": 255
+      },
+      "moves": [
+        "Thunderbolt",
+        "Drill Peck",
+        "Double-Edge",
+        "Thunder Wave"
+      ],
+      "nature": "Docile",
+      "item": "Scope Lens",
+      "tier": "50"
+    },
+    "Zapdos-6 (874)": {
+      "evs": {
+        "at": 170,
+        "sa": 170,
+        "sp": 170
+      },
+      "moves": [
+        "Thunder",
+        "Drill Peck",
+        "Rain Dance",
+        "Double-Edge"
+      ],
+      "nature": "Docile",
+      "item": "Lum Berry",
+      "tier": "50"
+    }
+  },
+  "Moltres": {
+    "Moltres-5 (875)": {
+      "evs": {
+        "sa": 255,
+        "sp": 255
+      },
+      "moves": [
+        "Overheat",
+        "Sunny Day",
+        "Swagger",
+        "Facade"
+      ],
+      "nature": "Docile",
+      "item": "White Herb",
+      "tier": "50"
+    },
+    "Moltres-6 (876)": {
+      "evs": {
+        "at": 255,
+        "sa": 255
+      },
+      "moves": [
+        "Overheat",
+        "Double-Edge",
+        "Aerial Ace",
+        "Steel Wing"
+      ],
+      "nature": "Docile",
+      "item": "White Herb",
+      "tier": "50"
+    }
+  },
+  "Raikou": {
+    "Raikou-5 (877)": {
+      "evs": {
+        "sa": 255,
+        "sp": 255
+      },
+      "moves": [
+        "Thunderbolt",
+        "Double-Edge",
+        "Roar",
+        "Reflect"
+      ],
+      "nature": "Modest",
+      "item": "BrightPowder",
+      "tier": "50"
+    },
+    "Raikou-6 (878)": {
+      "evs": {
+        "hp": 255,
+        "df": 255
+      },
+      "moves": [
+        "Thunderbolt",
+        "Calm Mind",
+        "Substitute",
+        "Rest"
+      ],
+      "nature": "Modest",
+      "item": "Chesto Berry",
+      "tier": "50"
+    }
+  },
+  "Entei": {
+    "Entei-5 (879)": {
+      "evs": {
+        "df": 255,
+        "sd": 255
+      },
+      "moves": [
+        "Fire Blast",
+        "Double-Edge",
+        "Endure",
+        "Reflect"
+      ],
+      "nature": "Docile",
+      "item": "Salac Berry",
+      "tier": "50"
+    },
+    "Entei-6 (880)": {
+      "evs": {
+        "df": 255,
+        "sd": 255
+      },
+      "moves": [
+        "Flamethrower",
+        "Calm Mind",
+        "Roar",
+        "Rest"
+      ],
+      "nature": "Modest",
+      "item": "Chesto Berry",
+      "tier": "50"
+    }
+  },
+  "Suicune": {
+    "Suicune-5 (881)": {
+      "evs": {
+        "hp": 255,
+        "sa": 255
+      },
+      "moves": [
+        "Surf",
+        "Ice Beam",
+        "Calm Mind",
+        "Icy Wind"
+      ],
+      "nature": "Modest",
+      "item": "Lum Berry",
+      "tier": "50"
+    },
+    "Suicune-6 (882)": {
+      "evs": {
+        "hp": 170,
+        "df": 170,
+        "sd": 170
+      },
+      "moves": [
+        "Surf",
+        "Ice Beam",
+        "Calm Mind",
+        "Rest"
+      ],
+      "nature": "Modest",
+      "item": "Chesto Berry",
       "tier": "50"
     }
   }

--- a/_scripts/setdex_gen4_sets.js
+++ b/_scripts/setdex_gen4_sets.js
@@ -5722,7 +5722,7 @@ SETDEX_PHGSS = {
       "moves": [
         "Gyro Ball",
         "Bug Bite",
-        "Revenge",
+        "Revenge (Doubled)",
         "Counter"
       ],
       "nature": "Brave",
@@ -7507,7 +7507,7 @@ SETDEX_PHGSS = {
         "at": 252
       },
       "moves": [
-        "Revenge",
+        "Revenge (Doubled)",
         "Payback",
         "Fling",
         "Fake Out"
@@ -10393,7 +10393,7 @@ SETDEX_PHGSS = {
         "sd": 252
       },
       "moves": [
-        "Revenge",
+        "Revenge (Doubled)",
         "Earthquake",
         "Payback",
         "Counter"
@@ -10441,7 +10441,7 @@ SETDEX_PHGSS = {
         "Dynamic Punch",
         "Vacuum Wave",
         "Foresight",
-        "Revenge"
+        "Revenge (Doubled)"
       ],
       "nature": "Brave",
       "item": "Focus Band",
@@ -13446,7 +13446,7 @@ SETDEX_PHGSS = {
       },
       "moves": [
         "X-Scissor",
-        "Revenge",
+        "Revenge (Doubled)",
         "Flail",
         "Endure"
       ],
@@ -14402,7 +14402,7 @@ SETDEX_PHGSS = {
       "moves": [
         "Aqua Tail",
         "Poison Jab",
-        "Revenge",
+        "Revenge (Doubled)",
         "Destiny Bond"
       ],
       "nature": "Adamant",
@@ -18885,7 +18885,7 @@ SETDEX_PHGSS = {
       },
       "moves": [
         "Poison Jab",
-        "Revenge",
+        "Revenge (Doubled)",
         "Bullet Punch",
         "X-Scissor"
       ],

--- a/_scripts/setdex_gen5_sets.js
+++ b/_scripts/setdex_gen5_sets.js
@@ -2500,7 +2500,7 @@ var SETDEX_GEN5 =
         "df": 252
       },
       "moves": [
-        "Revenge",
+        "Revenge (Doubled)",
         "Storm Throw",
         "Protect",
         "Seismic Toss"
@@ -9668,7 +9668,7 @@ var SETDEX_GEN5 =
       },
       "moves": [
         "Pursuit",
-        "Revenge",
+        "Revenge (Doubled)",
         "Retaliate",
         "Swagger"
       ],
@@ -9718,7 +9718,7 @@ var SETDEX_GEN5 =
         "Head Charge",
         "Bulldoze",
         "Stone Edge",
-        "Revenge"
+        "Revenge (Doubled)"
       ],
       "nature": "Adamant",
       "item": "Rocky Helmet"
@@ -14125,7 +14125,7 @@ var SETDEX_GEN5 =
       "moves": [
         "Razor Shell",
         "Aqua Jet",
-        "Revenge",
+        "Revenge (Doubled)",
         "Tail Whip"
       ],
       "nature": "Adamant",

--- a/_scripts/setdex_gen6_sets.js
+++ b/_scripts/setdex_gen6_sets.js
@@ -1518,7 +1518,7 @@ var SETDEX_GEN6 =
       },
       "moves": [
         "Pursuit",
-        "Revenge",
+        "Revenge (Doubled)",
         "Retaliate",
         "Swagger"
       ],
@@ -12145,7 +12145,7 @@ var SETDEX_GEN6 =
         "df": 252
       },
       "moves": [
-        "Revenge",
+        "Revenge (Doubled)",
         "Storm Throw",
         "Protect",
         "Seismic Toss"

--- a/_scripts/setdex_gen7_sets.js
+++ b/_scripts/setdex_gen7_sets.js
@@ -1962,7 +1962,7 @@ var SETDEX_GEN7 =
       },
       "moves": [
         "Pursuit",
-        "Revenge",
+        "Revenge (Doubled)",
         "Head Charge",
         "Swagger"
       ],
@@ -13898,7 +13898,7 @@ var SETDEX_GEN7 =
         "df": 252
       },
       "moves": [
-        "Revenge",
+        "Revenge (Doubled)",
         "Storm Throw",
         "Protect",
         "Seismic Toss"

--- a/_scripts/setdex_gen80_sets.js
+++ b/_scripts/setdex_gen80_sets.js
@@ -2611,7 +2611,7 @@ var SETDEX_GEN80 = {
         "Seed Bomb",
         "Sucker Punch",
         "Poison Jab",
-        "Revenge"
+        "Revenge (Doubled)"
       ],
       "nature": "Jolly",
       "ability": "Water Absorb",
@@ -11426,7 +11426,7 @@ var SETDEX_GEN80 = {
       },
       "moves": [
         "Seismic Toss",
-        "Revenge",
+        "Revenge (Doubled)",
         "Rock Tomb",
         "Scary Face"
       ],

--- a/_scripts/setdex_gen8_sets.js
+++ b/_scripts/setdex_gen8_sets.js
@@ -5552,7 +5552,7 @@ var SETDEX_GEN8 =
       "moves": [
         "Payback",
         "Protect",
-        "Revenge",
+        "Revenge (Doubled)",
         "Avalanche"
       ],
       "nature": "Brave",
@@ -7882,7 +7882,7 @@ var SETDEX_GEN8 =
         "sp": 16
       },
       "moves": [
-        "Revenge",
+        "Revenge (Doubled)",
         "Payback",
         "Counter",
         "Bullet Punch"
@@ -12400,7 +12400,7 @@ var SETDEX_GEN8 =
         "sp": 16
       },
       "moves": [
-        "Revenge",
+        "Revenge (Doubled)",
         "Iron Defense",
         "Protect",
         "Poison Jab"
@@ -12496,7 +12496,7 @@ var SETDEX_GEN8 =
         "sp": 27
       },
       "moves": [
-        "Revenge",
+        "Revenge (Doubled)",
         "Iron Defense",
         "Protect",
         "Poison Jab"
@@ -13767,7 +13767,7 @@ var SETDEX_GEN8 =
       },
       "moves": [
         "Shadow Ball",
-        "Revenge",
+        "Revenge (Doubled)",
         "Stone Edge",
         "Leech Life"
       ],
@@ -14282,7 +14282,7 @@ var SETDEX_GEN8 =
       "moves": [
         "Rest",
         "Sleep Talk",
-        "Revenge",
+        "Revenge (Doubled)",
         "Payback"
       ],
       "nature": "Careful",
@@ -20187,7 +20187,7 @@ var SETDEX_GEN8 =
         "Bulk Up",
         "Drain Punch",
         "Protect",
-        "Revenge"
+        "Revenge (Doubled)"
       ],
       "nature": "Careful",
       "item": "Leftovers",
@@ -20429,7 +20429,7 @@ var SETDEX_GEN8 =
       },
       "moves": [
         "First Impression",
-        "Revenge",
+        "Revenge (Doubled)",
         "Payback",
         "Counter"
       ],
@@ -25553,7 +25553,7 @@ var SETDEX_GEN8 =
       },
       "moves": [
         "Head Charge",
-        "Revenge",
+        "Revenge (Doubled)",
         "Earthquake",
         "Giga Impact"
       ],

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -1002,7 +1002,7 @@ $(".gen").change(function () {
 	switch (gen) {
 	case 3:
 		pokedex = POKEDEX_ADV;
-		setdex = SETDEX_EM;
+		setdex = joinDexes([SETDEX_EM, SETDEX_EM_OPEN_LVL]);
 		typeChart = TYPE_CHART_GSC;
 		moves = MOVES_ADV;
 		items = ITEMS_ADV;

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -558,6 +558,12 @@ function prependSpeciesAbilities(abilityList, pokeObjID, abilityObj) {
 		} else {
 			p2AbilityCount = abilityList.length;
 		}
+	} else {
+		if (pokeObjID === "p1") {
+			p1AbilityCount = 0;
+		} else {
+			p2AbilityCount = 0;
+		}
 	}
 }
 

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -926,7 +926,7 @@ function Field() {
 	var isHelpingHand = [$("#helpingHandR").prop("checked"), $("#helpingHandL").prop("checked")]; // affects attacks against opposite side
 	var isPowerSpot = [$("#powerSpotR").prop("checked"), $("#powerSpotL").prop("checked")]; // affects attacks against opposite side
 	var isFriendGuard = [$("#friendGuardL").prop("checked"), $("#friendGuardR").prop("checked")];
-	var isBattery = [$("#batteryR").prop("checked"), $("#batteryL").prop("checked")];
+	var isBattery = [$("#batteryR").prop("checked"), $("#batteryL").prop("checked")]; // affects attacks against opposite side
 	var isMinimized = [$("#minimL").prop("checked"), $("#minimR").prop("checked")];
 	var isVictoryStar = [$("#vicStarL").prop("checked"), $("#vicStarR").prop("checked")];
 	var isBusted8 = [$("#busted8L").prop("checked"), $("#busted8R").prop("checked")];
@@ -1164,6 +1164,8 @@ function clearField() {
 	$("#powerSpotR").prop("checked", false);
 	$("#friendGuardL").prop("checked", false);
 	$("#friendGuardR").prop("checked", false);
+	$("#batteryL").prop("checked", false);
+	$("#batteryR").prop("checked", false);
 	$("#clangL").prop("checked", false);
 	$("#clangR").prop("checked", false);
 	$("#wpL").prop("checked", false);


### PR DESCRIPTION
- Replaced current Revenge with Revenge (Doubled) to communicate to users how that move is calc'd, and added a 60 BP Revenge.
- Using the mass calc with gen 3 at level 50 will ignore the late-indexed sets that don't appear.
- Changing gens did not reset the Battery buttons.