### PR TITLE
Fix things that change move type for mass calc

### DIFF
--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -222,11 +222,17 @@ function getDamageResult(attacker, defender, move, field) {
 	if (attacker.ability === "Heavy Metal") {
 		attackerWeight *= 2;
 	} else if (attacker.ability === "Light Metal") {
+		attackerWeight = Math.floor(attackerWeight * 5) / 10; // weight values are truncated to the tenth's place (increments of 0.1)
+	}
+	if (attackerItem === "Float Stone") {
 		attackerWeight = Math.floor(attackerWeight * 5) / 10;
 	}
 	if (defender.ability === "Heavy Metal") {
 		defenderWeight *= 2;
 	} else if (defender.ability === "Light Metal") {
+		defenderWeight = Math.floor(defenderWeight * 5) / 10;
+	}
+	if (defender.item === "Float Stone") {
 		defenderWeight = Math.floor(defenderWeight * 5) / 10;
 	}
 
@@ -338,16 +344,15 @@ function getDamageResult(attacker, defender, move, field) {
 		break;
 	case "Low Kick":
 	case "Grass Knot":
-		var w = defenderWeight;
-		basePower = w >= 200 ? 120 : w >= 100 ? 100 : w >= 50 ? 80 : w >= 25 ? 60 : w >= 10 ? 40 : 20;
+		basePower = defenderWeight >= 200 ? 120 : defenderWeight >= 100 ? 100 : defenderWeight >= 50 ? 80 : defenderWeight >= 25 ? 60 : defenderWeight >= 10 ? 40 : 20;
 		description.moveBP = basePower;
 		break;
 	case "Crush Grip":
  	case "Wring Out":
-    		basePower = 100 * Math.floor((defender.curHP * 4096) / defender.maxHP);
-    		basePower = Math.floor(Math.floor((120 * basePower + 2048 - 1) / 4096) / 100) || 1;
-    		description.moveBP = basePower;
-    		break;
+		basePower = 100 * Math.floor((defender.curHP * 4096) / defender.maxHP);
+		basePower = Math.floor(Math.floor((120 * basePower + 2048 - 1) / 4096) / 100) || 1;
+		description.moveBP = basePower;
+		break;
 	case "Hex":
 	case "Infernal Parade":
 		basePower = move.bp * (defender.status !== "Healthy" ? 2 : 1);

--- a/_scripts/game_data/item_data.js
+++ b/_scripts/game_data/item_data.js
@@ -129,6 +129,7 @@ var ITEMS_DPP = ITEMS_ADV.concat([
 	"Smooth Rock",
 	"Splash Plate",
 	"Spooky Plate",
+	"Sticky Barb",
 	"Stone Plate",
 	"Tanga Berry",
 	"Toxic Orb",

--- a/_scripts/game_data/setdex_gen4_sets.js
+++ b/_scripts/game_data/setdex_gen4_sets.js
@@ -352,7 +352,7 @@ SETDEX_PHGSS = {
         "Future Sight"
       ],
       "nature": "Timid",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Alakazam-2 (537)": {
@@ -459,7 +459,7 @@ SETDEX_PHGSS = {
         "Dragon Dance"
       ],
       "nature": "Adamant",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Altaria-4 (812)": {
@@ -1369,7 +1369,7 @@ SETDEX_PHGSS = {
         "Synthesis"
       ],
       "nature": "Modest",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Bellossom-H": {
@@ -1571,7 +1571,7 @@ SETDEX_PHGSS = {
         "Sunny Day"
       ],
       "nature": "Timid",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Blaziken-3 (630)": {
@@ -1663,7 +1663,7 @@ SETDEX_PHGSS = {
         "Calm Mind"
       ],
       "nature": "Modest",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Blissey-4 (883)": {
@@ -1988,7 +1988,7 @@ SETDEX_PHGSS = {
         "Sweet Scent"
       ],
       "nature": "Modest",
-      "item": "Brightpowder"
+      "item": "BrightPowder"
     },
     "Bulbasaur-H": {
       "evs": {
@@ -2434,7 +2434,7 @@ SETDEX_PHGSS = {
         "Ancient Power"
       ],
       "nature": "Timid",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Charizard-H": {
@@ -2974,7 +2974,7 @@ SETDEX_PHGSS = {
         "Sing"
       ],
       "nature": "Adamant",
-      "item": "Brightpowder"
+      "item": "BrightPowder"
     },
     "Clefairy-H": {
       "evs": {
@@ -4647,7 +4647,7 @@ SETDEX_PHGSS = {
         "Thunder Wave"
       ],
       "nature": "Modest",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Electabuzz-H": {
@@ -4771,7 +4771,7 @@ SETDEX_PHGSS = {
         "Swagger"
       ],
       "nature": "Timid",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Electrode-3 (658)": {
@@ -5033,7 +5033,7 @@ SETDEX_PHGSS = {
         "Attract"
       ],
       "nature": "Timid",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Espeon-3 (727)": {
@@ -5126,7 +5126,7 @@ SETDEX_PHGSS = {
         "Sunny Day"
       ],
       "nature": "Modest",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Exeggutor-2 (585)": {
@@ -5987,7 +5987,7 @@ SETDEX_PHGSS = {
         "Ice Punch"
       ],
       "nature": "Jolly",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Gallade-3 (720)": {
@@ -6049,7 +6049,7 @@ SETDEX_PHGSS = {
         "Sandstorm"
       ],
       "nature": "Jolly",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Garchomp-2 (621)": {
@@ -6156,7 +6156,7 @@ SETDEX_PHGSS = {
         "Focus Blast"
       ],
       "nature": "Modest",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Gardevoir-4 (855)": {
@@ -7636,7 +7636,7 @@ SETDEX_PHGSS = {
         "Dark Pulse"
       ],
       "nature": "Modest",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Heatran-4 (948)": {
@@ -8377,7 +8377,7 @@ SETDEX_PHGSS = {
         "Sunny Day"
       ],
       "nature": "Modest",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Infernape-4 (769)": {
@@ -9332,7 +9332,7 @@ SETDEX_PHGSS = {
         "Thunderbolt"
       ],
       "nature": "Modest",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Lapras-H": {
@@ -9425,7 +9425,7 @@ SETDEX_PHGSS = {
         "Shadow Ball"
       ],
       "nature": "Timid",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Latias-4 (946)": {
@@ -9502,7 +9502,7 @@ SETDEX_PHGSS = {
         "Energy Ball"
       ],
       "nature": "Timid",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Latios-4 (947)": {
@@ -9564,7 +9564,7 @@ SETDEX_PHGSS = {
         "Grass Whistle"
       ],
       "nature": "Jolly",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Leafeon-3 (729)": {
@@ -9890,7 +9890,7 @@ SETDEX_PHGSS = {
         "Thunder Wave"
       ],
       "nature": "Jolly",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Lopunny-3 (663)": {
@@ -9983,7 +9983,7 @@ SETDEX_PHGSS = {
         "Roar"
       ],
       "nature": "Modest",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Lucario-2 (595)": {
@@ -10860,7 +10860,7 @@ SETDEX_PHGSS = {
         "Signal Beam"
       ],
       "nature": "Modest",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Magnezone-H": {
@@ -11014,7 +11014,7 @@ SETDEX_PHGSS = {
         "Swift"
       ],
       "nature": "Timid",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Manectric-H": {
@@ -11292,7 +11292,7 @@ SETDEX_PHGSS = {
         "Iron Defense"
       ],
       "nature": "Impish",
-      "item": "Brightpowder"
+      "item": "BrightPowder"
     },
     "Mawile-H": {
       "evs": {
@@ -11478,7 +11478,7 @@ SETDEX_PHGSS = {
         "Light Screen"
       ],
       "nature": "Adamant",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Metagross-2 (620)": {
@@ -12449,7 +12449,7 @@ SETDEX_PHGSS = {
         "Substitute"
       ],
       "nature": "Careful",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Nidoking-3 (680)": {
@@ -12650,7 +12650,7 @@ SETDEX_PHGSS = {
         "Sunny Day"
       ],
       "nature": "Timid",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Ninetales-2 (570)": {
@@ -14483,7 +14483,7 @@ SETDEX_PHGSS = {
         "Thunder Wave"
       ],
       "nature": "Adamant",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Raichu-H": {
@@ -14699,7 +14699,7 @@ SETDEX_PHGSS = {
         "Horn Drill"
       ],
       "nature": "Adamant",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Rapidash-4 (825)": {
@@ -14917,7 +14917,7 @@ SETDEX_PHGSS = {
         "Drain Punch"
       ],
       "nature": "Adamant",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Regigigas-H": {
@@ -15815,7 +15815,7 @@ SETDEX_PHGSS = {
         "Baton Pass"
       ],
       "nature": "Impish",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Scizor-2 (559)": {
@@ -15906,7 +15906,7 @@ SETDEX_PHGSS = {
         "Swords Dance"
       ],
       "nature": "Adamant",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Scyther-H": {
@@ -17039,7 +17039,7 @@ SETDEX_PHGSS = {
         "Sweet Kiss"
       ],
       "nature": "Mild",
-      "item": "Brightpowder"
+      "item": "BrightPowder"
     },
     "Smoochum-H": {
       "evs": {
@@ -19214,7 +19214,7 @@ SETDEX_PHGSS = {
         "Moonlight"
       ],
       "nature": "Impish",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Umbreon-H": {
@@ -19323,7 +19323,7 @@ SETDEX_PHGSS = {
         "Baton Pass"
       ],
       "nature": "Modest",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Vaporeon-2 (588)": {
@@ -19927,7 +19927,7 @@ SETDEX_PHGSS = {
         "Confuse Ray"
       ],
       "nature": "Calm",
-      "item": "Brightpowder"
+      "item": "BrightPowder"
     },
     "Vulpix-H": {
       "evs": {
@@ -20205,7 +20205,7 @@ SETDEX_PHGSS = {
         "Hail"
       ],
       "nature": "Jolly",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Weavile-3 (712)": {
@@ -20821,7 +20821,7 @@ SETDEX_PHGSS = {
         "Signal Beam"
       ],
       "nature": "Modest",
-      "item": "Brightpowder",
+      "item": "BrightPowder",
       "tier": "50"
     },
     "Zapdos-H": {

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -132,6 +132,12 @@ function performCalculations() {
 	var dataSet = [];
 	var userPoke = new Pokemon($("#p1"));
 	var startingBoosts = [userPoke.boosts.at, userPoke.boosts.df, userPoke.boosts.sa, userPoke.boosts.sd, userPoke.boosts.sp, userPoke.boosts.ac, userPoke.boosts.es];
+	var startingMoveTypes = [userPoke.moves[0].type, userPoke.moves[1].type, userPoke.moves[2].type, userPoke.moves[3].type];
+	if (mode === "one-vs-all") {
+		attacker = userPoke;
+	} else {
+		defender = userPoke;
+	}
 	var field = new Field();
 	var startingWeather = field.getWeather();
 	var counter = 0;
@@ -153,10 +159,8 @@ function performCalculations() {
 
 			if (mode === "one-vs-all") {
 				defender = setPoke;
-				attacker = userPoke;
 			} else {
 				attacker = setPoke;
-				defender = userPoke;
 			}
 			if (attacker.ability === "Rivalry") {
 				attacker.gender = "N";
@@ -206,6 +210,11 @@ function performCalculations() {
 			userPoke.boosts.ac = startingBoosts[5];
 			userPoke.boosts.es = startingBoosts[6];
 			userPoke.stats = [];
+			// reset changed move properties
+			userPoke.moves[0].type = startingMoveTypes[0];
+			userPoke.moves[1].type = startingMoveTypes[1];
+			userPoke.moves[2].type = startingMoveTypes[2];
+			userPoke.moves[3].type = startingMoveTypes[3];
 			// the only Field object "property" that can be modified is weather
 			field.setWeather(startingWeather);
 			counter++;

--- a/_scripts/ko_chance.js
+++ b/_scripts/ko_chance.js
@@ -57,15 +57,7 @@ function getKOChanceText(damage, move, defender, field, isBadDreams, attacker, i
 		return includeAcc ? ("guaranteed OHKO" + (move.acc ? " (" + (100 * (moveAccuracy / 100)).toFixed(2) + "% after accuracy)" : "")) : "guaranteed OHKO";
 	} else if (damage.length === 256 && hasSitrus && damage[0] >= defender.curHP + Math.floor(defender.maxHP / 4)) {
 		return includeAcc ? ("guaranteed OHKO" + (move.acc ? " (" + (100 * (moveAccuracy / 100)).toFixed(2) + "% after accuracy)" : "")) : "guaranteed OHKO";
-	} else if (damage.length === 256 && hasFigy && damage[0] >= defender.curHP + Math.floor(defender.maxHP / (gen === 8 ? 3 : 2))) {
-		return includeAcc ? ("guaranteed OHKO" + (move.acc ? " (" + (100 * (moveAccuracy / 100)).toFixed(2) + "% after accuracy)" : "")) : "guaranteed OHKO";
-	} else if (damage.length === 256 && hasIapapa && damage[0] >= defender.curHP + Math.floor(defender.maxHP / (gen === 8 ? 3 : 2))) {
-		return includeAcc ? ("guaranteed OHKO" + (move.acc ? " (" + (100 * (moveAccuracy / 100)).toFixed(2) + "% after accuracy)" : "")) : "guaranteed OHKO";
-	} else if (damage.length === 256 && hasWiki && damage[0] >= defender.curHP + Math.floor(defender.maxHP / (gen === 8 ? 3 : 2))) {
-		return includeAcc ? ("guaranteed OHKO" + (move.acc ? " (" + (100 * (moveAccuracy / 100)).toFixed(2) + "% after accuracy)" : "")) : "guaranteed OHKO";
-	} else if (damage.length === 256 && hasAguav && damage[0] >= defender.curHP + Math.floor(defender.maxHP / (gen === 8 ? 3 : 2))) {
-		return includeAcc ? ("guaranteed OHKO" + (move.acc ? " (" + (100 * (moveAccuracy / 100)).toFixed(2) + "% after accuracy)" : "")) : "guaranteed OHKO";
-	} else if (damage.length === 256 && hasMago && damage[0] >= defender.curHP + Math.floor(defender.maxHP / (gen === 8 ? 3 : 2))) {
+	} else if (damage.length === 256 && (hasFigy || hasIapapa || hasWiki || hasAguav || hasMago) && damage[0] >= defender.curHP + Math.floor(defender.maxHP / (gen === 8 ? 3 : 2))) {
 		return includeAcc ? ("guaranteed OHKO" + (move.acc ? " (" + (100 * (moveAccuracy / 100)).toFixed(2) + "% after accuracy)" : "")) : "guaranteed OHKO";
 	}
 
@@ -271,8 +263,9 @@ function getKOChanceText(damage, move, defender, field, isBadDreams, attacker, i
 		} else if (c > 0) {
 			var pct = Math.round(c * 1000) / 10;
 			var chance = pct ? qualifier + pct : "Miniscule";
+			var chanceAcc = (chance * (Math.pow(moveAccuracy / 100, i) * 100) / 100);
 			if (includeAcc) {
-				return chance + "% chance to " + i + "HKO" + afterText + (move.acc ? " (" + (chance * (Math.pow(moveAccuracy / 100, i) * 100) / 100).toFixed(2) + "% chance to " + i + "HKO after accuracy)" : "");
+				return chance + "% chance to " + i + "HKO" + afterText + (move.acc ? " (" + (chanceAcc ? chanceAcc.toFixed(2) : "Miniscule") + "% chance to " + i + "HKO after accuracy)" : "");
 			}
 			else {
 				return chance + "% chance to " + i + "HKO";


### PR DESCRIPTION
- Prevent move typing from being permanently changed by the mass calc (something with Pixilate would then have incorrect calcs).
- Added Float Stone functionality
- Somehow Sticky Barb was missing? Really only added it for RS sets completeness.
- Fixed a minor bug that could sometimes cause moves to display NaN in the chance to KO after accuracy.