### PR TITLE
Sets now use Avalanche (Doubled)

### DIFF
--- a/_scripts/game_data/move_data.js
+++ b/_scripts/game_data/move_data.js
@@ -1980,7 +1980,7 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
 		"makesContact": true,
 		"acc": 100
 	},
-	"Avalanche (doubled)": {
+	"Avalanche (Doubled)": {
 		"bp": 120,
 		"type": "Ice",
 		"category": "Physical",
@@ -3739,6 +3739,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
 		"type": "Ice"
 	},
 	"Avalanche": {"zp": 120},
+	"Avalanche (Doubled)": {"zp": 120},
 	"Baneful Bunker": {
 		"bp": 0,
 		"type": "Poison"

--- a/_scripts/game_data/setdex_gen4_sets.js
+++ b/_scripts/game_data/setdex_gen4_sets.js
@@ -53,7 +53,7 @@ SETDEX_PHGSS = {
       },
       "moves": [
         "Wood Hammer",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Earthquake",
         "Rock Slide"
       ],
@@ -68,7 +68,7 @@ SETDEX_PHGSS = {
       },
       "moves": [
         "Wood Hammer",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Brick Break",
         "Iron Tail"
       ],
@@ -270,7 +270,7 @@ SETDEX_PHGSS = {
       "moves": [
         "Iron Tail",
         "Dragon Rush",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Aerial Ace"
       ],
       "nature": "Adamant",
@@ -962,7 +962,7 @@ SETDEX_PHGSS = {
         "df": 252
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Aerial Ace",
         "Facade",
         "Reflect"
@@ -1210,7 +1210,7 @@ SETDEX_PHGSS = {
       "moves": [
         "Metal Burst",
         "Stone Edge",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Curse"
       ],
       "nature": "Adamant",
@@ -1505,7 +1505,7 @@ SETDEX_PHGSS = {
       "moves": [
         "Aqua Tail",
         "Earthquake",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Zen Headbutt"
       ],
       "nature": "Adamant",
@@ -3013,7 +3013,7 @@ SETDEX_PHGSS = {
         "df": 252
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Dive",
         "Toxic",
         "Protect"
@@ -3701,7 +3701,7 @@ SETDEX_PHGSS = {
       },
       "moves": [
         "Waterfall",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Headbutt",
         "Fake Out"
       ],
@@ -5229,7 +5229,7 @@ SETDEX_PHGSS = {
       "moves": [
         "Facade",
         "Earthquake",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Crunch"
       ],
       "nature": "Adamant",
@@ -6537,7 +6537,7 @@ SETDEX_PHGSS = {
         "sd": 168
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Payback",
         "Gyro Ball",
         "Ice Shard"
@@ -9282,7 +9282,7 @@ SETDEX_PHGSS = {
       },
       "moves": [
         "Aqua Tail",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Ice Shard",
         "Curse"
       ],
@@ -10901,7 +10901,7 @@ SETDEX_PHGSS = {
         "at": 252
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Earthquake",
         "Iron Head",
         "Curse"
@@ -14603,7 +14603,7 @@ SETDEX_PHGSS = {
       "moves": [
         "Stone Edge",
         "Payback",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Fling"
       ],
       "nature": "Brave",
@@ -14648,7 +14648,7 @@ SETDEX_PHGSS = {
       "moves": [
         "Head Smash",
         "Zen Headbutt",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Fire Punch"
       ],
       "nature": "Adamant",
@@ -14802,7 +14802,7 @@ SETDEX_PHGSS = {
         "df": 252
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Hammer Arm",
         "Double Team",
         "Curse"
@@ -14848,7 +14848,7 @@ SETDEX_PHGSS = {
       },
       "moves": [
         "Blizzard",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Hyper Beam",
         "Thunder Wave"
       ],
@@ -15209,7 +15209,7 @@ SETDEX_PHGSS = {
         "Outrage",
         "Hammer Arm",
         "Shadow Claw",
-        "Avalanche"
+        "Avalanche (Doubled)"
       ],
       "nature": "Brave",
       "item": "Persim Berry",
@@ -15316,7 +15316,7 @@ SETDEX_PHGSS = {
       },
       "moves": [
         "Horn Drill",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Payback",
         "Counter"
       ],
@@ -16865,7 +16865,7 @@ SETDEX_PHGSS = {
         "Zen Headbutt",
         "Aqua Tail",
         "Earthquake",
-        "Avalanche"
+        "Avalanche (Doubled)"
       ],
       "nature": "Adamant",
       "item": "Expert Belt",
@@ -17201,7 +17201,7 @@ SETDEX_PHGSS = {
         "df": 252
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Ice Shard",
         "Frustration",
         "Hail"
@@ -17233,7 +17233,7 @@ SETDEX_PHGSS = {
       },
       "moves": [
         "Wood Hammer",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Ingrain",
         "Giga Drain"
       ],
@@ -18114,7 +18114,7 @@ SETDEX_PHGSS = {
       "moves": [
         "Earthquake",
         "Aqua Tail",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Mirror Coat"
       ],
       "nature": "Adamant",
@@ -19088,7 +19088,7 @@ SETDEX_PHGSS = {
       "moves": [
         "Rock Slide",
         "Payback",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Curse"
       ],
       "nature": "Brave",
@@ -19242,7 +19242,7 @@ SETDEX_PHGSS = {
       "moves": [
         "Slash",
         "Payback",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Counter"
       ],
       "nature": "Brave",
@@ -20015,7 +20015,7 @@ SETDEX_PHGSS = {
       },
       "moves": [
         "Waterfall",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Earthquake",
         "Curse"
       ],
@@ -20076,7 +20076,7 @@ SETDEX_PHGSS = {
         "at": 252
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Earthquake",
         "Crunch",
         "Curse"

--- a/_scripts/game_data/setdex_gen5_sets.js
+++ b/_scripts/game_data/setdex_gen5_sets.js
@@ -180,7 +180,7 @@ var SETDEX_GEN5 =
         "Fake Out",
         "Earthquake",
         "Aqua Tail",
-        "Avalanche"
+        "Avalanche (Doubled)"
       ],
       "nature": "Adamant",
       "item": "Leftovers",
@@ -579,7 +579,7 @@ var SETDEX_GEN5 =
       },
       "moves": [
         "Earthquake",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Waterfall",
         "Stone Edge"
       ],
@@ -6636,7 +6636,7 @@ var SETDEX_GEN5 =
       },
       "moves": [
         "Waterfall",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Aqua Ring",
         "Curse"
       ],
@@ -9557,7 +9557,7 @@ var SETDEX_GEN5 =
       "moves": [
         "Shadow Claw",
         "Stone Edge",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Bulk Up"
       ],
       "nature": "Brave",
@@ -9588,7 +9588,7 @@ var SETDEX_GEN5 =
       },
       "moves": [
         "Swords Dance",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Rock Slide",
         "Brick Break"
       ],
@@ -9634,7 +9634,7 @@ var SETDEX_GEN5 =
         "at": 252
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Dive",
         "Superpower",
         "Sheer Cold"
@@ -9781,7 +9781,7 @@ var SETDEX_GEN5 =
       "moves": [
         "Iron Tail",
         "Dragon Rush",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Aerial Ace"
       ],
       "nature": "Adamant",
@@ -10180,7 +10180,7 @@ var SETDEX_GEN5 =
       },
       "moves": [
         "Horn Drill",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Payback",
         "Counter"
       ],
@@ -10363,7 +10363,7 @@ var SETDEX_GEN5 =
         "at": 252
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Ice Shard",
         "Natural Gift",
         "Giga Impact"
@@ -14010,7 +14010,7 @@ var SETDEX_GEN5 =
         "at": 252
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Shadow Claw",
         "Aerial Ace",
         "Slash"

--- a/_scripts/game_data/setdex_gen6_sets.js
+++ b/_scripts/game_data/setdex_gen6_sets.js
@@ -299,7 +299,7 @@ var SETDEX_GEN6 =
       "moves": [
         "Iron Tail",
         "Dragon Rush",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Stone Edge"
       ],
       "nature": "Adamant",
@@ -976,7 +976,7 @@ var SETDEX_GEN6 =
         "df": 252
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Confide",
         "Protect",
         "Toxic"
@@ -1025,7 +1025,7 @@ var SETDEX_GEN6 =
       },
       "moves": [
         "Stone Edge",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Gyro Ball",
         "Earthquake"
       ],
@@ -1174,7 +1174,7 @@ var SETDEX_GEN6 =
       "moves": [
         "Shadow Claw",
         "Stone Edge",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Bulk Up"
       ],
       "nature": "Brave",
@@ -1205,7 +1205,7 @@ var SETDEX_GEN6 =
       },
       "moves": [
         "Swords Dance",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Rock Slide",
         "Brick Break"
       ],
@@ -1337,7 +1337,7 @@ var SETDEX_GEN6 =
         "Fake Out",
         "Earthquake",
         "Aqua Tail",
-        "Avalanche"
+        "Avalanche (Doubled)"
       ],
       "nature": "Adamant",
       "item": "Leftovers",
@@ -5579,7 +5579,7 @@ var SETDEX_GEN6 =
       },
       "moves": [
         "Double-Edge",
-        "Eathquake",
+        "Earthquake",
         "Wild Charge",
         "Outrage"
       ],
@@ -10142,7 +10142,7 @@ var SETDEX_GEN6 =
       },
       "moves": [
         "Horn Drill",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Payback",
         "Counter"
       ],
@@ -11701,7 +11701,7 @@ var SETDEX_GEN6 =
       },
       "moves": [
         "Earthquake",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Waterfall",
         "Stone Edge"
       ],
@@ -12993,7 +12993,7 @@ var SETDEX_GEN6 =
         "at": 252
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Ice Shard",
         "Natural Gift",
         "Giga Impact"
@@ -13538,7 +13538,7 @@ var SETDEX_GEN6 =
       },
       "moves": [
         "Waterfall",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Aqua Ring",
         "Curse"
       ],

--- a/_scripts/game_data/setdex_gen7_sets.js
+++ b/_scripts/game_data/setdex_gen7_sets.js
@@ -1171,7 +1171,7 @@ var SETDEX_GEN7 =
         "df": 252
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Confide",
         "Protect",
         "Toxic"
@@ -1218,7 +1218,7 @@ var SETDEX_GEN7 =
       },
       "moves": [
         "Stone Edge",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Gyro Ball",
         "Earthquake"
       ],
@@ -1494,7 +1494,7 @@ var SETDEX_GEN7 =
       "moves": [
         "Shadow Claw",
         "Stone Edge",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Bulk Up"
       ],
       "nature": "Brave",
@@ -1524,7 +1524,7 @@ var SETDEX_GEN7 =
       },
       "moves": [
         "Swords Dance",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Rock Slide",
         "Brick Break"
       ],
@@ -8656,7 +8656,7 @@ var SETDEX_GEN7 =
       "moves": [
         "Hail",
         "Earthquake",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Fissure"
       ],
       "nature": "Adamant",
@@ -15131,7 +15131,7 @@ var SETDEX_GEN7 =
         "at": 252
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Ice Shard",
         "Natural Gift",
         "Giga Impact"

--- a/_scripts/game_data/setdex_gen80_sets.js
+++ b/_scripts/game_data/setdex_gen80_sets.js
@@ -36,7 +36,7 @@ var SETDEX_GEN80 = {
         "Wood Hammer",
         "Ingrain",
         "Substitute",
-        "Avalanche"
+        "Avalanche (Doubled)"
       ],
       "nature": "Adamant",
       "ability": "Snow Warning",
@@ -422,7 +422,7 @@ var SETDEX_GEN80 = {
       },
       "moves": [
         "Stone Edge",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Payback",
         "Earthquake"
       ],
@@ -5498,7 +5498,7 @@ var SETDEX_GEN80 = {
       "moves": [
         "Waterfall",
         "Aqua Jet",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Earthquake"
       ],
       "nature": "Adamant",
@@ -5923,7 +5923,7 @@ var SETDEX_GEN80 = {
       "moves": [
         "Giga Impact",
         "Earthquake",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Crunch"
       ],
       "nature": "Careful",
@@ -7426,7 +7426,7 @@ var SETDEX_GEN80 = {
       "moves": [
         "Hyper Beam",
         "Mirror Coat",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Freeze-Dry"
       ],
       "nature": "Naughty",
@@ -11784,7 +11784,7 @@ var SETDEX_GEN80 = {
       "moves": [
         "Fissure",
         "Double Team",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Earthquake"
       ],
       "nature": "Careful",
@@ -13197,7 +13197,7 @@ var SETDEX_GEN80 = {
       "moves": [
         "Rock Slide",
         "Dig",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Waterfall"
       ],
       "nature": "Adamant",
@@ -13501,7 +13501,7 @@ var SETDEX_GEN80 = {
       "ivs": {},
       "moves": [
         "Stone Edge",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Iron Tail",
         "Aerial Ace"
       ],
@@ -16205,7 +16205,7 @@ var SETDEX_GEN80 = {
         "Rock Blast",
         "Fire Fang",
         "Earthquake",
-        "Avalanche"
+        "Avalanche (Doubled)"
       ],
       "nature": "Brave",
       "ability": "Lightning Rod",
@@ -16315,7 +16315,7 @@ var SETDEX_GEN80 = {
         "Stone Edge",
         "Megahorn",
         "Dragon Rush",
-        "Avalanche"
+        "Avalanche (Doubled)"
       ],
       "nature": "Impish",
       "ability": "Solid Rock",
@@ -19496,7 +19496,7 @@ var SETDEX_GEN80 = {
       "moves": [
         "Ancient Power",
         "Muddy Water",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Focus Blast"
       ],
       "nature": "Sassy",
@@ -19579,7 +19579,7 @@ var SETDEX_GEN80 = {
         "Earthquake",
         "Waterfall",
         "Rock Tomb",
-        "Avalanche"
+        "Avalanche (Doubled)"
       ],
       "nature": "Adamant",
       "ability": "Torrent",
@@ -21710,7 +21710,7 @@ var SETDEX_GEN80 = {
         "Defense Curl",
         "Rollout",
         "Waterfall",
-        "Avalanche"
+        "Avalanche (Doubled)"
       ],
       "nature": "Adamant",
       "ability": "Pressure",

--- a/_scripts/game_data/setdex_gen8_sets.js
+++ b/_scripts/game_data/setdex_gen8_sets.js
@@ -3963,7 +3963,7 @@ var SETDEX_GEN8 =
       },
       "moves": [
         "Sheer Cold",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Explosion",
         "Ice Shard"
       ],
@@ -4109,7 +4109,7 @@ var SETDEX_GEN8 =
       },
       "moves": [
         "High Horsepower",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Curse",
         "Body Press"
       ],
@@ -5162,7 +5162,7 @@ var SETDEX_GEN8 =
       "moves": [
         "Seed Bomb",
         "Ice Shard",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Protect"
       ],
       "nature": "Brave",
@@ -5553,7 +5553,7 @@ var SETDEX_GEN8 =
         "Payback",
         "Protect",
         "Revenge (Doubled)",
-        "Avalanche"
+        "Avalanche (Doubled)"
       ],
       "nature": "Brave",
       "item": "Focus Sash",
@@ -15234,7 +15234,7 @@ var SETDEX_GEN8 =
       "moves": [
         "Earthquake",
         "Stone Edge",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Hammer Arm"
       ],
       "nature": "Brave",
@@ -15298,7 +15298,7 @@ var SETDEX_GEN8 =
       "moves": [
         "Earthquake",
         "Stone Edge",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Hammer Arm"
       ],
       "nature": "Brave",
@@ -16078,7 +16078,7 @@ var SETDEX_GEN8 =
       "moves": [
         "Yawn",
         "Focus Punch",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Aqua Jet"
       ],
       "nature": "Brave",
@@ -21574,7 +21574,7 @@ var SETDEX_GEN8 =
         "sp": 16
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "High Horsepower",
         "Hail",
         "Aurora Veil"
@@ -21598,7 +21598,7 @@ var SETDEX_GEN8 =
         "sp": 19
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "High Horsepower",
         "Body Press",
         "Curse"
@@ -21622,7 +21622,7 @@ var SETDEX_GEN8 =
         "sp": 23
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "High Horsepower",
         "Gyro Ball",
         "Mirror Coat"
@@ -21646,7 +21646,7 @@ var SETDEX_GEN8 =
         "sp": 27
       },
       "moves": [
-        "Avalanche",
+        "Avalanche (Doubled)",
         "High Horsepower",
         "Gyro Ball",
         "Stone Edge"
@@ -21821,7 +21821,7 @@ var SETDEX_GEN8 =
         "Perish Song",
         "Protect",
         "Whirlpool",
-        "Avalanche"
+        "Avalanche (Doubled)"
       ],
       "nature": "Relaxed",
       "item": "Sitrus Berry",
@@ -22961,7 +22961,7 @@ var SETDEX_GEN8 =
       },
       "moves": [
         "Payback",
-        "Avalanche",
+        "Avalanche (Doubled)",
         "Rest",
         "Sleep Talk"
       ],


### PR DESCRIPTION
Since Avalanche was split into a 60 BP and 120 BP move, AI sets have been changed to use Avalanche (Doubled).