### PR TITLE
Triple Axel, Recoil/Recovery text, and more

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-include: ['_pages', '_css', '_scripts', '_images']
+include: ['_css', '_scripts', '_images']
 
 title: Battle Facilities Calculator
 

--- a/_scripts/ap_calc.js
+++ b/_scripts/ap_calc.js
@@ -38,48 +38,50 @@ function calculate() {
 	// Removed the auto-select highest damage since it's rarely useful for facilities (or any format?)
 	//var highestMaxPercent = -1;
 	//var bestResult = $(resultLocations[0][0].move);
+	let p1Move, p2Move;
 	for (var i = 0; i < 4; i++) {
 		result = damageResults[0][i];
-		minDamage = result.damage[0] * p1.moves[i].hits;
-		maxDamage = result.damage[result.damage.length - 1] * p1.moves[i].hits;
+		p1Move = p1.moves[i];
+		minDamage = result.damage[0] * (p1Move.name === "Triple Axel" ? 1 : p1Move.hits); // Triple Axel already handles its extra hit(s) in the damage script
+		maxDamage = result.damage[result.damage.length - 1] * (p1Move.name === "Triple Axel" ? 1 : p1Move.hits);
 		minPercent = Math.floor(minDamage * 1000 / p2.maxHP) / 10;
 		maxPercent = Math.floor(maxDamage * 1000 / p2.maxHP) / 10;
 		result.damageText = minDamage + "-" + maxDamage + " (" + minPercent + " - " + maxPercent + "%)";
-		result.koChanceText = p1.moves[i].bp === 0 ? "nice move" :
-			getKOChanceText(result.damage, p1.moves[i], p2, field.getSide(1), p1.ability === "Bad Dreams", p1, p2.isMinimized, p1.isVictoryStar, gen, true);
-		if (p1.moves[i].isMLG && p1.level >= p2.level) {
+		result.koChanceText = p1Move.bp === 0 ? "nice move" :
+			getKOChanceText(result.damage, p1Move, p2, field.getSide(1), p1.ability === "Bad Dreams", p1, p2.isMinimized, p1.isVictoryStar, gen, true);
+		if (p1Move.isMLG && p1.level >= p2.level) {
 			result.koChanceText = "<a href = 'https://www.youtube.com/watch?v=iD92h-M474g'>it's a one-hit KO!</a>"; //dank memes
 		}
 		var recoveryText = "";
-		if (p1.moves[i].givesHealth) {
-			var minHealthRecovered = "%" === "%" ? Math.floor(minDamage * p1.moves[i].percentHealed * 1000 / p1.maxHP) /
-                10 : Math.floor(minDamage * p1.moves[i].percentHealed * 48 / p1.maxHP);
-			var maxHealthRecovered = "%" === "%" ? Math.floor(maxDamage * p1.moves[i].percentHealed * 1000 / p1.maxHP) /
-                10 : Math.floor(maxDamage * p1.moves[i].percentHealed * 48 / p1.maxHP);
+		if (p1Move.givesHealth) {
+			var minHealthRecovered = "%" === "%" ? Math.floor(minDamage * p1Move.percentHealed * 1000 / p1.maxHP) /
+                10 : Math.floor(minDamage * p1Move.percentHealed * 48 / p1.maxHP);
+			var maxHealthRecovered = "%" === "%" ? Math.floor(maxDamage * p1Move.percentHealed * 1000 / p1.maxHP) /
+                10 : Math.floor(maxDamage * p1Move.percentHealed * 48 / p1.maxHP);
 			if (minHealthRecovered > 100 && "%" === "%") {
-				minHealthRecovered = Math.floor(p2.maxHP * p1.moves[i].percentHealed * 1000 / p1.maxHP) / 10;
-				maxHealthRecovered = Math.floor(p2.maxHP * p1.moves[i].percentHealed * 1000 / p1.maxHP) / 10;
+				minHealthRecovered = Math.floor(p2.maxHP * p1Move.percentHealed * 1000 / p1.maxHP) / 10;
+				maxHealthRecovered = Math.floor(p2.maxHP * p1Move.percentHealed * 1000 / p1.maxHP) / 10;
 			} else if ("%" !== "%" && minHealthRecovered > 48) {
-				minHealthRecovered = Math.floor(p2.maxHP * p1.moves[i].percentHealed * 48 / p1.maxHP);
-				maxHealthRecovered = Math.floor(p2.maxHP * p1.moves[i].percentHealed * 48 / p1.maxHP);
+				minHealthRecovered = Math.floor(p2.maxHP * p1Move.percentHealed * 48 / p1.maxHP);
+				maxHealthRecovered = Math.floor(p2.maxHP * p1Move.percentHealed * 48 / p1.maxHP);
 			}
 			recoveryText = " (recovers between " + minHealthRecovered + "%" + " and " + maxHealthRecovered + "%" + ")";
 		}
 		var recoilText = "";
-		if (typeof p1.moves[i].hasRecoil === "number") {
+		if (typeof p1Move.hasRecoil === "number") {
 			var damageOverflow = minDamage > p2.curHP || maxDamage > p2.curHP;
-			var minRecoilDamage = "%" === "%" ? Math.floor(Math.min(minDamage, p2.curHP) * p1.moves[i].hasRecoil * 10 / p1.maxHP) / 10 :
-				Math.floor(Math.min(minDamage, p2.curHP) * p1.moves[i].hasRecoil * 0.48 / p1.maxHP);
-			var maxRecoilDamage = "%" === "%" ? Math.floor(Math.min(maxDamage, p2.curHP) * p1.moves[i].hasRecoil * 10 / p1.maxHP) / 10 :
-				Math.floor(Math.min(maxDamage, p2.curHP) * p1.moves[i].hasRecoil * 0.48 / p1.maxHP);
+			var minRecoilDamage = "%" === "%" ? Math.floor(Math.min(minDamage, p2.curHP) * p1Move.hasRecoil * 10 / p1.maxHP) / 10 :
+				Math.floor(Math.min(minDamage, p2.curHP) * p1Move.hasRecoil * 0.48 / p1.maxHP);
+			var maxRecoilDamage = "%" === "%" ? Math.floor(Math.min(maxDamage, p2.curHP) * p1Move.hasRecoil * 10 / p1.maxHP) / 10 :
+				Math.floor(Math.min(maxDamage, p2.curHP) * p1Move.hasRecoil * 0.48 / p1.maxHP);
 			if (damageOverflow) {
-				minRecoilDamage = "%" === "%" ? Math.floor(p2.curHP * p1.moves[i].hasRecoil * 10 / p1.maxHP) / 10 :
-					Math.floor(p2.maxHP * p1.moves[i].hasRecoil * 0.48 / p1.maxHP);
-				maxRecoilDamage = "%" === "%" ? Math.floor(p2.curHP * p1.moves[i].hasRecoil * 10 / p1.maxHP) / 10 :
-					Math.floor(p2.curHP * p1.moves[i].hasRecoil * 0.48 / p1.maxHP);
+				minRecoilDamage = "%" === "%" ? Math.floor(p2.curHP * p1Move.hasRecoil * 10 / p1.maxHP) / 10 :
+					Math.floor(p2.maxHP * p1Move.hasRecoil * 0.48 / p1.maxHP);
+				maxRecoilDamage = "%" === "%" ? Math.floor(p2.curHP * p1Move.hasRecoil * 10 / p1.maxHP) / 10 :
+					Math.floor(p2.curHP * p1Move.hasRecoil * 0.48 / p1.maxHP);
 			}
 			recoilText = " (" + minRecoilDamage + " - " + maxRecoilDamage + "%" + " recoil damage)";
-		} else if (p1.moves[i].hasRecoil === "crash") {
+		} else if (p1Move.hasRecoil === "crash") {
 			var genMultiplier = gen === 2 ? 12.5 : gen >= 3 ? 50 : 1;
 			var gen4CrashDamage = Math.floor(p2.maxHP * 0.5 / p1.maxHP * 100);
 			var minRecoilDamage = "%" === "%" ? Math.floor(Math.min(minDamage, p2.maxHP) * genMultiplier * 10 / p1.maxHP) / 10 :
@@ -98,12 +100,12 @@ function calculate() {
 						gen === 4 ? (p2.type1 === "Ghost" || p2.type2 === "Ghost") ? " (" + gen4CrashDamage + "% crash damage)" : " (" + minRecoilDamage + " - " + maxRecoilDamage + "%" + " crash damage on miss)" :
 							gen > 4 ? " (50% crash damage)" :
 								"";
-		} else if (p1.moves[i].hasRecoil === "Struggle") {
+		} else if (p1Move.hasRecoil === "Struggle") {
 			recoilText = " (25% struggle damage)";
-		} else if (p1.moves[i].hasRecoil) {
+		} else if (p1Move.hasRecoil) {
 			recoilText = " (50% recoil damage)";
 		}
-		$(resultLocations[0][i].move + " + label").text(p1.moves[i].name.replace("Hidden Power", "HP"));
+		$(resultLocations[0][i].move + " + label").text(p1Move.name.replace("Hidden Power", "HP"));
 		$(resultLocations[0][i].damage).text(minPercent + " - " + maxPercent + "%" + recoveryText + recoilText);
 		/*if (maxPercent > highestMaxPercent) {
 			highestMaxPercent = maxPercent;
@@ -112,45 +114,46 @@ function calculate() {
 
 		result = damageResults[1][i];
 		var recoveryText = "";
-		minDamage = result.damage[0] * p2.moves[i].hits;
-		maxDamage = result.damage[result.damage.length - 1] * p2.moves[i].hits;
+		p2Move = p2.moves[i];
+		minDamage = result.damage[0] * (p2Move.name === "Triple Axel" ? 1 : p2Move.hits);
+		maxDamage = result.damage[result.damage.length - 1] * (p2Move.name === "Triple Axel" ? 1 : p2Move.hits);
 		minPercent = Math.floor(minDamage * 1000 / p1.maxHP) / 10;
 		maxPercent = Math.floor(maxDamage * 1000 / p1.maxHP) / 10;
 		result.damageText = minDamage + "-" + maxDamage + " (" + minPercent + " - " + maxPercent + "%)";
-		result.koChanceText = p2.moves[i].bp === 0 ? "nice move" :
-			getKOChanceText(result.damage, p2.moves[i], p1, field.getSide(0), p2.ability === "Bad Dreams", p2, p1.isMinimized, p2.isVictoryStar, gen, true);
-		if (p2.moves[i].isMLG) {
+		result.koChanceText = p2Move.bp === 0 ? "nice move" :
+			getKOChanceText(result.damage, p2Move, p1, field.getSide(0), p2.ability === "Bad Dreams", p2, p1.isMinimized, p2.isVictoryStar, gen, true);
+		if (p2Move.isMLG) {
 			result.koChanceText = "<a href = 'https://www.youtube.com/watch?v=iD92h-M474g'>it's a one-hit KO!</a>";
 		}
-		if (p2.moves[i].givesHealth) {
-			var minHealthRecovered = "%" === "%" ? Math.floor(minDamage * p2.moves[i].percentHealed * 1000 / p2.maxHP) /
-                10 : Math.floor(minDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
-			var maxHealthRecovered = "%" === "%" ? Math.floor(maxDamage * p2.moves[i].percentHealed * 1000 / p2.maxHP) /
-                10 : Math.floor(maxDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
+		if (p2Move.givesHealth) {
+			var minHealthRecovered = "%" === "%" ? Math.floor(minDamage * p2Move.percentHealed * 1000 / p2.maxHP) /
+                10 : Math.floor(minDamage * p2Move.percentHealed * 48 / p2.maxHP);
+			var maxHealthRecovered = "%" === "%" ? Math.floor(maxDamage * p2Move.percentHealed * 1000 / p2.maxHP) /
+                10 : Math.floor(maxDamage * p2Move.percentHealed * 48 / p2.maxHP);
 			if (minHealthRecovered > 100 && "%" === "%") {
-				minHealthRecovered = Math.floor(p1.maxHP * p2.moves[i].percentHealed * 1000 / p2.maxHP) / 10;
-				maxHealthRecovered = Math.floor(p1.maxHP * p2.moves[i].percentHealed * 1000 / p2.maxHP) / 10;
+				minHealthRecovered = Math.floor(p1.maxHP * p2Move.percentHealed * 1000 / p2.maxHP) / 10;
+				maxHealthRecovered = Math.floor(p1.maxHP * p2Move.percentHealed * 1000 / p2.maxHP) / 10;
 			} else if ("%" !== "%" && minHealthRecovered > 48) {
-				minHealthRecovered = Math.floor(p1.maxHP * p2.moves[i].percentHealed * 48 / p2.maxHP);
-				maxHealthRecovered = Math.floor(p1.maxHP * p2.moves[i].percentHealed * 48 / p2.maxHP);
+				minHealthRecovered = Math.floor(p1.maxHP * p2Move.percentHealed * 48 / p2.maxHP);
+				maxHealthRecovered = Math.floor(p1.maxHP * p2Move.percentHealed * 48 / p2.maxHP);
 			}
 			recoveryText = " (recovers between " + minHealthRecovered + "%" + " and " + maxHealthRecovered + "%" + ")";
 		}
 		var recoilText = "";
-		if (typeof p2.moves[i].hasRecoil === "number") {
+		if (typeof p2Move.hasRecoil === "number") {
 			var damageOverflow = minDamage > p1.curHP || maxDamage > p1.curHP;
-			var minRecoilDamage = "%" === "%" ? Math.floor(Math.min(minDamage, p1.curHP) * p2.moves[i].hasRecoil * 10 / p2.maxHP) / 10 :
-				Math.floor(Math.min(minDamage, p1.curHP) * p2.moves[i].hasRecoil * 0.48 / p2.maxHP);
-			var maxRecoilDamage = "%" === "%" ? Math.floor(Math.min(maxDamage, p1.maxHP) * p2.moves[i].hasRecoil * 10 / p2.maxHP) / 10 :
-				Math.floor(Math.min(maxDamage, p1.curHP) * p2.moves[i].hasRecoil * 0.48 / p2.maxHP);
+			var minRecoilDamage = "%" === "%" ? Math.floor(Math.min(minDamage, p1.curHP) * p2Move.hasRecoil * 10 / p2.maxHP) / 10 :
+				Math.floor(Math.min(minDamage, p1.curHP) * p2Move.hasRecoil * 0.48 / p2.maxHP);
+			var maxRecoilDamage = "%" === "%" ? Math.floor(Math.min(maxDamage, p1.maxHP) * p2Move.hasRecoil * 10 / p2.maxHP) / 10 :
+				Math.floor(Math.min(maxDamage, p1.curHP) * p2Move.hasRecoil * 0.48 / p2.maxHP);
 			if (damageOverflow) {
-				minRecoilDamage = "%" === "%" ? Math.floor(Math.min(p1.maxHP * p2.moves[i].hasRecoil) * 10 / p2.maxHP) / 10 :
-					Math.floor(p1.maxHP * p2.moves[i].recoilPercentage * 0.48 / p1.maxHP);
-				maxRecoilDamage = "%" === "%" ? Math.floor(Math.min(p1.maxHP, p2.moves[i].hasRecoil) * 10 / p2.maxHP) / 10 :
-					Math.floor(Math.min(p1.maxHP, p2.moves[i].hasRecoil) * 0.48 / p2.maxHP);
+				minRecoilDamage = "%" === "%" ? Math.floor(Math.min(p1.maxHP * p2Move.hasRecoil) * 10 / p2.maxHP) / 10 :
+					Math.floor(p1.maxHP * p2Move.recoilPercentage * 0.48 / p1.maxHP);
+				maxRecoilDamage = "%" === "%" ? Math.floor(Math.min(p1.maxHP, p2Move.hasRecoil) * 10 / p2.maxHP) / 10 :
+					Math.floor(Math.min(p1.maxHP, p2Move.hasRecoil) * 0.48 / p2.maxHP);
 			}
 			recoilText = " (" + minRecoilDamage + " - " + maxRecoilDamage + "%" + " recoil damage)";
-		} else if (p2.moves[i].hasRecoil === "crash") {
+		} else if (p2Move.hasRecoil === "crash") {
 			var genMultiplier = gen === 2 ? 12.5 : gen >= 3 ? 50 : 1;
 			var gen4CrashDamage = Math.floor(p2.maxHP * 0.5 / p1.maxHP * 100);
 			var minRecoilDamage = "%" === "%" ? Math.floor(Math.min(minDamage, p1.maxHP) * genMultiplier * 10 / p2.maxHP) / 10 :
@@ -169,12 +172,12 @@ function calculate() {
 						gen === 4 ? (p1.type1 === "Ghost" || p1.type2 === "Ghost") ? " (" + gen4CrashDamage + "% crash damage)" : " (" + minRecoilDamage + " - " + maxRecoilDamage + "%" + " crash damage on miss)" :
 							gen > 4 ? " (50% crash damage)" :
 								"";
-		} else if (p2.moves[i].hasRecoil === "Struggle") {
+		} else if (p2Move.hasRecoil === "Struggle") {
 			recoilText = " (25% struggle damage)";
-		} else if (p2.moves[i].hasRecoil) {
+		} else if (p2Move.hasRecoil) {
 			recoilText = " (50% recoil damage)";
 		}
-		$(resultLocations[1][i].move + " + label").text(p2.moves[i].name.replace("Hidden Power", "HP"));
+		$(resultLocations[1][i].move + " + label").text(p2Move.name.replace("Hidden Power", "HP"));
 		$(resultLocations[1][i].damage).text(minPercent + " - " + maxPercent + "%" + recoveryText + recoilText);
 		/*if (maxPercent > highestMaxPercent) {
 			highestMaxPercent = maxPercent;

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -180,7 +180,6 @@ function getDamageResult(attacker, defender, move, field) {
 	case "Tera Blast":
 		if (attacker.isTerastal) {
 			move.type = attacker.type1;
-			description.moveType = move.type;
 		}
 		break;
 

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -980,6 +980,7 @@ function getDamageResult(attacker, defender, move, field) {
 		}
 	}
 	if (move.name === "Triple Axel") {
+		// normally damage get multiplied by the number of hits right before being displayed to the player. Triple Axel has an exception.
 		for (let h = 1; h < move.hits; h++) {
 			finalBasePower = Math.max(1, pokeRound((basePower * (h + 1) * chainMods(bpMods)) / 4096));
 			baseDamage = Math.floor(Math.floor(Math.floor(2 * attacker.level / 5 + 2) * finalBasePower * attack / defense) / 50 + 2);

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -466,17 +466,12 @@ function getDamageResult(attacker, defender, move, field) {
 	}
 
 	var bpMods = [];
-	if (gen >= 8) {
-		// The location of these modifiers changed betweens gens 7 and 8 https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8433978
-		if (attacker.ability === "Technician" && basePower <= 60 ||
-			attacker.ability === "Flare Boost" && attacker.status === "Burned" && move.category === "Special" ||
-			attacker.ability === "Toxic Boost" && (attacker.status === "Poisoned" || attacker.status === "Badly Poisoned") && move.category === "Physical" ||
-			attacker.ability === "Strong Jaw" && move.isBite ||
-			attacker.ability === "Mega Launcher" && move.isPulse) {
-			bpMods.push(0x1800);
-			description.attackerAbility = attacker.ability;
-		}
+	// The location of Technician changed betweens gens 7 and 8 https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8433978
+	if (gen >= 8 && attacker.ability === "Technician" && basePower <= 60) {
+		bpMods.push(0x1800);
+		description.attackerAbility = attacker.ability;
 	}
+
 	if (field.isSteelySpirit && move.type === "Steel") {
 		bpMods.push(0x1800);
 		description.isSteelySpirit = true;
@@ -554,16 +549,17 @@ function getDamageResult(attacker, defender, move, field) {
 		}
 	}
 
-	if (gen < 8) {
-		// The location of these modifiers changed betweens gens 7 and 8 https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8433978
-		if (attacker.ability === "Technician" && basePower <= 60 ||
-			attacker.ability === "Flare Boost" && attacker.status === "Burned" && move.category === "Special" ||
-			attacker.ability === "Toxic Boost" && (attacker.status === "Poisoned" || attacker.status === "Badly Poisoned") && move.category === "Physical" ||
-			attacker.ability === "Strong Jaw" && move.isBite ||
-			attacker.ability === "Mega Launcher" && move.isPulse) {
-			bpMods.push(0x1800);
-			description.attackerAbility = attacker.ability;
-		}
+	// The location of Technician changed betweens gens 7 and 8 https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8433978
+	if (gen < 8 && attacker.ability === "Technician" && pokeRound((basePower * chainMods(bpMods)) / 4096) <= 60) {
+		bpMods.push(0x1800);
+		description.attackerAbility = attacker.ability;
+	}
+	if (attacker.ability === "Flare Boost" && attacker.status === "Burned" && move.category === "Special" ||
+		attacker.ability === "Toxic Boost" && (attacker.status === "Poisoned" || attacker.status === "Badly Poisoned") && move.category === "Physical" ||
+		attacker.ability === "Strong Jaw" && move.isBite ||
+		attacker.ability === "Mega Launcher" && move.isPulse) {
+		bpMods.push(0x1800);
+		description.attackerAbility = attacker.ability;
 	}
 
 	if (defAbility === "Heatproof" && move.type === "Fire") {

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -798,12 +798,12 @@ function getDamageResult(attacker, defender, move, field) {
 	}
 
 	var defenderProtoQuark = checkProtoQuarkHighest(defender, field.weather, field.terrain);
-	if ((defenderProtoQuark === "Def" && move.category === "Physical") || (defenderProtoQuark === "SpD" && move.category === "Special")) {
+	if ((defenderProtoQuark === "Def" && hitsPhysical) || (defenderProtoQuark === "SpD" && !hitsPhysical)) {
 		dfMods.push(0x14CD);
 		description.defenderAbility = defAbility;
 	}
 
-	if ((field.isRuinSword && move.category === "Physical") || (field.isRuinBeads && move.category === "Special")) {
+	if ((field.isRuinSword && hitsPhysical) || (field.isRuinBeads && !hitsPhysical)) {
 		dfMods.push(0xC00);
 		description.isRuinDef = true;
 	}

--- a/_scripts/game_data/move_data.js
+++ b/_scripts/game_data/move_data.js
@@ -138,7 +138,7 @@ var MOVES_RBY = {
 		"type": "Normal",
 		"category": "Physical",
 		"makesContact": true,
-		"hasRecoil": 25,
+		"hasRecoil": 1/4,
 		"acc": 100
 	},
 	"Double Team": {
@@ -157,7 +157,7 @@ var MOVES_RBY = {
 		"type": "Psychic",
 		"category": "Special",
 		"givesHealth": true,
-		"percentHealed": 0.5,
+		"percentHealed": 1/2,
 		"acc": 0x1000
 	},
 	"Drill Peck": {
@@ -345,7 +345,7 @@ var MOVES_RBY = {
 		"category": "Physical",
 		"makesContact": true,
 		"givesHealth": true,
-		"percentHealed": 0.5,
+		"percentHealed": 1/2,
 		"acc": 100
 	},
 	"Leech Seed": {
@@ -376,7 +376,7 @@ var MOVES_RBY = {
 		"type": "Grass",
 		"category": "Special",
 		"givesHealth": true,
-		"percentHealed": 0.5,
+		"percentHealed": 1/2,
 		"acc": 100
 	},
 	"Mega Kick": {
@@ -592,7 +592,7 @@ var MOVES_RBY = {
 		"bp": 50,
 		"type": "Normal",
 		"category": "Physical",
-		"hasRecoil": 50,
+		"hasRecoil": 1/2,
 		"acc": 101
 	},
 	"Stun Spore": {
@@ -604,7 +604,7 @@ var MOVES_RBY = {
 		"type": "Fighting",
 		"category": "Physical",
 		"makesContact": true,
-		"hasRecoil": 25,
+		"hasRecoil": 1/4,
 		"acc": 80
 	},
 	"Substitute": {
@@ -651,8 +651,8 @@ var MOVES_RBY = {
 		"type": "Normal",
 		"category": "Physical",
 		"makesContact": true,
-		"hasRecoil": 25,
-		"acc": 90
+		"hasRecoil": 1/4,
+		"acc": 85
 	},
 	"Thrash": {
 		"bp": 90,
@@ -901,7 +901,7 @@ var MOVES_GSC = $.extend(true, {}, MOVES_RBY, {
 		"type": "Grass",
 		"category": "Special",
 		"givesHealth": true,
-		"percentHealed": 0.5,
+		"percentHealed": 1/2,
 		"acc": 100
 	},
 	"Gust": {
@@ -1249,7 +1249,7 @@ var MOVES_GSC = $.extend(true, {}, MOVES_RBY, {
 		"hasSecondaryEffect": true,
 		"acc": 90
 	},
-	"Struggle": {"type": "None", "hasRecoil": 25},
+	"Struggle": {"type": "None", "hasRecoil": 1/4},
 	"Sunny Day": {
 		"bp": 0,
 		"type": "Fire"
@@ -1437,7 +1437,7 @@ var MOVES_ADV = $.extend(true, {}, MOVES_GSC, {
 		"bp": 0,
 		"type": "Dragon"
 	},
-	"Double-Edge": {"hasRecoil": 33},
+	"Double-Edge": {"hasRecoil": 1/3},
 	"Endeavor": {
 		"bp": 1,
 		"type": "Normal",
@@ -1881,7 +1881,7 @@ var MOVES_ADV = $.extend(true, {}, MOVES_GSC, {
 		"category": "Physical",
 		"makesContact": true,
 		"hasSecondaryEffect": true,
-		"hasRecoil": 33,
+		"hasRecoil": 1/3,
 		"acc": 100
 	},
 	"Water Pulse": {
@@ -1992,7 +1992,7 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
 		"type": "Flying",
 		"category": "Physical",
 		"makesContact": true,
-		"hasRecoil": 33,
+		"hasRecoil": 1/3,
 		"acc": 100
 	},
 	"Brine": {
@@ -2138,7 +2138,7 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
 		"makesContact": true,
 		"isPunch": true,
 		"givesHealth": true,
-		"percentHealed": 0.5,
+		"percentHealed": 1/2,
 		"acc": 100
 	},
 	"Earth Power": {
@@ -2183,7 +2183,7 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
 		"category": "Physical",
 		"makesContact": true,
 		"hasSecondaryEffect": true,
-		"hasRecoil": 33,
+		"hasRecoil": 1/3,
 		"acc": 100
 	},
 	"Flash Cannon": {
@@ -2266,7 +2266,7 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
 		"type": "Rock",
 		"category": "Physical",
 		"makesContact": true,
-		"hasRecoil": 50,
+		"hasRecoil": 1/2,
 		"acc": 80
 	},
 	"Heal Order": {
@@ -2620,7 +2620,7 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
 		"type": "Grass",
 		"category": "Physical",
 		"makesContact": true,
-		"hasRecoil": 33,
+		"hasRecoil": 1/3,
 		"acc": 100
 	},
 	"Worry Seed": {
@@ -2915,7 +2915,7 @@ var MOVES_BW = $.extend(true, {}, MOVES_DPP, {
 		"type": "Normal",
 		"category": "Physical",
 		"makesContact": true,
-		"hasRecoil": 25,
+		"hasRecoil": 1/4,
 		"acc": 100
 	},
 	"Heat Crash": {
@@ -2948,7 +2948,7 @@ var MOVES_BW = $.extend(true, {}, MOVES_DPP, {
 		"category": "Physical",
 		"makesContact": true,
 		"givesHealth": true,
-		"percentHealed": 0.5,
+		"percentHealed": 1/2,
 		"acc": 100
 	},
 	"Hurricane": {
@@ -3261,7 +3261,7 @@ var MOVES_BW = $.extend(true, {}, MOVES_DPP, {
 		"type": "Electric",
 		"category": "Physical",
 		"makesContact": true,
-		"hasRecoil": 25,
+		"hasRecoil": 1/4,
 		"acc": 100
 	},
 	"Wonder Room": {
@@ -3351,7 +3351,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
 		"category": "Special",
 		"makesContact": true,
 		"givesHealth": true,
-		"percentHealed": 0.75,
+		"percentHealed": 3/4,
 		"acc": 100
 	},
 	"Eerie Impulse": {
@@ -3478,7 +3478,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
 		"bp": 140,
 		"type": "Fairy",
 		"category": "Special",
-		"hasRecoil": 50,
+		"hasRecoil": 1/2,
 		"acc": 100
 	},
 	"Low Sweep": {"bp": 65},
@@ -3528,7 +3528,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
 		"type": "Flying",
 		"category": "Special",
 		"givesHealth": true,
-		"percentHealed": 0.75,
+		"percentHealed": 3/4,
 		"acc": 100
 	},
 	"Origin Pulse": {
@@ -3545,7 +3545,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
 		"type": "Electric",
 		"category": "Special",
 		"givesHealth": true,
-		"percentHealed": 0.5,
+		"percentHealed": 1/2,
 		"acc": 100
 	},
 	"Petal Blizzard": {
@@ -5191,7 +5191,7 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 		"category": "Physical",
 		"makesContact": true,
 		"givesHealth": true,
-		"percentHealed": 0.5,
+		"percentHealed": 1/2,
 		"isSlicing": true,
 		"acc": 100
 	},
@@ -5633,7 +5633,7 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 		"type": "Water",
 		"category": "Physical",
 		"makesContact": true,
-		"hasRecoil": 33,
+		"hasRecoil": 1/3,
 		"acc": 100
 	},
 	"Wildbolt Storm": {

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -177,8 +177,8 @@ function performCalculations() {
 			for (let n = 0; n < 4; n++) {
 				result = damageResults[n];
 				attackerMove = attacker.moves[n];
-				minDamage = result.damage[0] * attackerMove.hits;
-				maxDamage = result.damage[result.damage.length - 1] * attackerMove.hits;
+				minDamage = result.damage[0] * (attackerMove.name === "Triple Axel" ? 1 : attackerMove.hits); // Triple Axel already handles its extra hit(s) in the damage script
+				maxDamage = result.damage[result.damage.length - 1] * (attackerMove.name === "Triple Axel" ? 1 : attackerMove.hits);
 				// If any piece of the calculation is a string and not a number ie. Pokemon.level, stats will concatinate into strings, and the below will eval to 0.
 				// I want to be very sure that everything is using the correct types, so I want this behavior. Shoutouts to writing code w/o tests.
 				minPercentage = Math.floor(minDamage * 1000 / defender.maxHP) / 10;

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -785,8 +785,8 @@ function Pokemon(pokeInfo) {
 function getMoveDetails(moveInfo, item, species) {
 	var moveName = moveInfo.find("select.move-selector").val();
 	var defaultDetails = moves[moveName];
-	var isZMove = gen == 7 && moveInfo.find("input.move-z").prop("checked");
-	var isMax = gen == 8 && moveInfo.find("input.move-max").prop("checked");
+	var isZMove = gen == 7 && moveInfo.find("input.move-z").prop("checked") && moveName !== "Struggle";
+	var isMax = gen == 8 && moveInfo.find("input.move-max").prop("checked") && moveName !== "Struggle";
 
 	if (isMax) {
 		var exceptions_100_fight = ["Low Kick", "Reversal", "Final Gambit"];

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -883,6 +883,7 @@ function getMoveDetails(moveInfo, item, species) {
 			"type": moveInfo.find(".move-type").val(),
 			"category": moveInfo.find(".move-cat").val(),
 			"isCrit": moveInfo.find(".move-crit").prop("checked"),
+			"isZ": moveName === "Nature Power" && isZMove,
 			"isMax": isMax,
 			"hits": defaultDetails.maxMultiHits ? ~~moveInfo.find(".move-hits").val() : defaultDetails.isThreeHit ? 3 : defaultDetails.isTwoHit ? 2 : 1,
 			"usedTimes": defaultDetails.dropsStats ? ~~moveInfo.find(".stat-drops").val() : 1


### PR DESCRIPTION
- Triple Axel now calculates a 20, 40, and 60 BP hit. The prior method of calcing three 40 BP hits (or two 30's) was nicely close but not quite accurate. % chance to KO is still displayed as 90% for an OHKO, however. Maybe another day that'll get solved.
- Completely refactored the horrible Recoil and Recovery code in order to fix bugs. Recoil and Recovery text has been added to the long description. Shell Bell, Big Root, and Liquid Ooze have been implemented.
- Misty Explosion and Stored Power now properly check for isGrounded for applying their additional power/effects.
- Sword/Beads of Ruin and Proto/Quark now interact correctly with (Psyshock, Psystrike, Secret Sword). The incorrect defense stat was accounted for previously.
- I noticed that the description has an underutilized option for move type so moves with changable types now add their type to the description.
- Some damage values displayed as a percentage now rounds to the tenth's place instead of flooring to it.
- Minor accuracy update for Technician.
- Fixed Nature Power's interaction with Z-moves. Will anyone care that this move works correctly now? Probably not!