### PR TITLE
Shedinja damage and small updates

### DIFF
--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -1231,15 +1231,21 @@ function getModdedWeight(pokemon, ability) {
 
 function killsShedinja(attacker, defender, move) {
 	// This is meant to at-a-glance highlight moves that are fatal to Shedinja and allow the mass calc to better capture Shedinja's defensive profile.
+	// sorry for the mess of conditionals
 	if (defender.ability === "Wonder Guard" && defender.curHP == 1) {
-		let weather = defender.item !== "Safety Goggles" && ((move.name === "Sandstorm" && !defender.hasType("Rock")) || (move.name === "Hail" && !defender.hasType("Ice")));
+		let poisonable = defender.status === "Healthy" && !defender.hasType("Poison") && !defender.hasType("Steel");
+		let burnable = defender.status === "Healthy" && !defender.hasType("Fire");
+
+		let weather = defender.item !== "Safety Goggles" &&
+		((move.name === "Sandstorm" && (!defender.hasType("Rock") && !defender.hasType("Steel") && !defender.hasType("Ground"))) || (move.name === "Hail" && !defender.hasType("Ice")));
 		// akin to Sash, status berries should not be accounted for
-		let poison = defender.status === "Healthy" && ["Toxic", "Poison Gas", "Poison Powder", "Toxic Thread"].includes(move.name) && ((!defender.hasType("Poison") && !defender.hasType("Steel")) || attacker.ability === "Corrosion");
-		let burn = move.name === "Will-O-Wisp" && !defender.hasType("Fire");
-		let dangerItem = ["Flame Orb", "Toxic Orb", "Sticky Barb"].includes(attacker.item) && (["Trick", "Switcheroo"].includes(move.name) || (move.name === "Bestow" && defender.item === ""));
-		if (weather || poison || burn || dangerItem) {
-			return true;
-		}
+		let poison = ["Toxic", "Poison Gas", "Poison Powder", "Toxic Thread"].includes(move.name) && (poisonable || (attacker.ability === "Corrosion" && defender.status === "Healthy"));
+		let burn = move.name === "Will-O-Wisp" && burnable;
+		let dangerItem = (["Trick", "Switcheroo"].includes(move.name) || (move.name === "Bestow" && defender.item === "")) &&
+		(attacker.item === "Sticky Barb" || (attacker.item === "Toxic Orb" && poisonable) || (attacker.item === "Flame Orb" && burnable));
+		let confusion = ["Confuse Ray", "Flatter", "Supersonic", "Swagger", "Sweet Kiss", "Teeter Dance"].includes(move.name);
+		let otherPassive = (move.name === "Leech Seed" && !defender.hasType("Grass")) || (move.name === "Curse" && attacker.hasType("Ghost"));
+		return weather || poison || burn || dangerItem || confusion || otherPassive;
 	}
 	return false;
 }

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -558,11 +558,10 @@ function getDamageResult(attacker, defender, move, field) {
 		bpMods.push(0x1199); // confirmed to be 0x1199 from gens 5-9 by https://www.smogon.com/bw/articles/bw_complete_damage_formula and OZY's Twitter
 		description.attackerItem = attacker.item;
 	} else if (attacker.item === "Punching Glove" && move.isPunch) {
-		// It seems to be an ever-so-slightly-different multiplier from Band/Glasses https://twitter.com/OZY_Project97/status/1604385021439094784
-		bpMods.push(0x119A);
+		bpMods.push(0x119A); // it seems to be an ever-so-slightly-different multiplier from Band/Glasses https://twitter.com/OZY_Project97/status/1604385021439094784
 		description.attackerItem = attacker.item;
 	} else if ((getItemBoostType(attacker.item) === moveType) ||
-		(attacker.hasType(moveType) && ( // this probably no longer works correctly under Terastallization; can check dex types instead
+		((attacker.dexType1 === moveType || attacker.dexType2 === moveType) && (
 		attacker.item === "Adamant Orb" && attacker.name === "Dialga" ||
 		attacker.item === "Lustrous Orb" && attacker.name === "Palkia" ||
 		attacker.item === "Griseous Orb" && attacker.name === "Giratina-O" ||

--- a/_scripts/game_data/stat_data.js
+++ b/_scripts/game_data/stat_data.js
@@ -15,7 +15,7 @@ function CALC_HP_ADV(poke) {
 		total = Math.floor((base * 2 + ivs + Math.floor(evs / 4)) * level / 100) + level + 10;
 	}
 
-	if (poke.find(".max").prop("checked")) {
+	if (poke.find(".max").prop("checked") && total > 1) {
 		var dmaxLevel = poke.find(".max-level").val();
 		total = Math.floor(total * (1.5 + (dmaxLevel * 0.05)));
 	}

--- a/_scripts/ko_chance.js
+++ b/_scripts/ko_chance.js
@@ -7,7 +7,8 @@ function setKOChanceText(result, move, attacker, defender, field) {
 	var moveAccuracy = "";
 	var ignoreAccMods = false;
 	if (move.acc || move.isZ) {
-		if (move.isZ || move.acc === 101 || (move.name === "Blizzard" && (field.weather === "Hail" || field.weather === "Snow")) || ((move.name === "Thunder" || move.name === "Hurricane") && field.weather.includes("Rain")) ||
+		// all genie sig moves have perfect acc in rain, except the pink one's.
+		if (move.isZ || move.acc === 101 || (move.name === "Blizzard" && (field.weather === "Hail" || field.weather === "Snow")) || (["Thunder", "Hurricane", "Bleakwind Storm", "Sandsear Storm", "Wildbolt Storm"].includes(move.name) && field.weather.includes("Rain")) ||
 			(["Astonish", "Body Slam", "Dragon Rush", "Extrasensory", "Flying Press", "Heat Crash", "Heavy Slam", "Malicious Moonsault", "Needle Arm", "Phantom Force", "Shadow Force", "Steamroller", "Stomp"].includes(move.name) && defender.isMinimized)) {
 			moveAccuracy = 100;
 			ignoreAccMods = true;

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -584,21 +584,17 @@ function prependSpeciesAbilities(abilityList, pokeObjID, abilityObj) {
 }
 
 function showFormes(formeObj, setName, pokemonName, pokemon) {
-	var defaultForme = 0;
+	let defaultForme = 0;
 
 	if (setName !== "Blank Set") {
-		var set = setdexAll[pokemonName][setName];
-
+		let set = setdexAll[pokemonName][setName];
 		if (set.forme) {
 			defaultForme = pokedex[pokemonName].formes.indexOf(set.forme);
-		}
-
-		if (set.isGmax) {
+		} else if (set.isGmax) {
 			defaultForme = 1;
 		}
-
-		// This code needs to stay intact for old saved Mega sets that don't have the forme field
-		if (set.item) {
+		else if (set.item) {
+			// This code needs to stay intact for old saved Mega sets that don't have the forme field
 			if (set.item !== "Eviolite" && (set.item.endsWith("ite") || set.item.endsWith("ite X"))) {
 				defaultForme = 1;
 			} else if (set.item.endsWith("ite Y")) {
@@ -607,7 +603,7 @@ function showFormes(formeObj, setName, pokemonName, pokemon) {
 		}
 	}
 
-	var formeOptions = getSelectOptions(pokemon.formes, false, defaultForme);
+	let formeOptions = getSelectOptions(pokemon.formes, false, defaultForme);
 	formeObj.children("select").find("option").remove().end().append(formeOptions).change();
 	formeObj.show();
 }


### PR DESCRIPTION
- Items like the Griseous Orb or Soul Dew that boost two move types will now work correctly with Terastallized Pokemon.
- The gen 5 genie signature moves are perfectly accurate in rain.
- Intimidate is now blocked by White Herb, and Mirror Armor no longer reflects it.
- Small bug fixes and code improvements.

Previously undocumented changes:
   - If level is not specified in the Showdown format import, it will default to the current autolevel level.
   - Status moves that are fatal to Shedinja now deal 1 damage. This PR includes an update to that logic.
   - Regular Darmanitan had Gorilla Tactics as an ability instead of Sheer Force.
   - Screens were using the singles damage reduction value in doubles. Text has been added to the move description to indicate when screens use the doubles reduction value.