### PR TITLE
Parental Bond fixes, Neutralizing Gas, and code rework

### DIFF
--- a/_css/ap_calc.css
+++ b/_css/ap_calc.css
@@ -165,7 +165,7 @@ th {
 .move-result-group {
   max-width: 80em;
   min-width: 50em;
-  margin: 1em 0 11.5em;
+  margin: 1em 0 10em;
 }
 
 .move-result-subgroup {

--- a/_css/dark_ap_calc.css
+++ b/_css/dark_ap_calc.css
@@ -177,7 +177,7 @@ th {
 .move-result-group {
   max-width: 80em;
   min-width: 50em;
-  margin: 1em 0 11.5em;
+  margin: 1em 0 10em;
 }
 
 .move-result-subgroup {

--- a/_scripts/ap_calc.js
+++ b/_scripts/ap_calc.js
@@ -90,8 +90,8 @@ function calculate() {
 	}
 	bestResult.prop("checked", true);
 	bestResult.change();*/
-	$("#resultHeaderL").text(p1.name + "'s Moves (select one to show detailed results)");
-	$("#resultHeaderR").text(p2.name + "'s Moves (select one to show detailed results)");
+	//$("#resultHeaderL").text(p1.name + "'s Moves (select one to show detailed results)");
+	//$("#resultHeaderR").text(p2.name + "'s Moves (select one to show detailed results)");
 	updateDamageText($("input:radio[name='resultMove']:checked"));
 }
 

--- a/_scripts/ap_calc.js
+++ b/_scripts/ap_calc.js
@@ -1,5 +1,6 @@
 $("#p1 .ability").bind("keyup change", function () {
 	autoSetCrits($("#p1"), 1);
+	checkNeutralizingGas();
 });
 
 $("#p1 .status").bind("keyup change", function () {
@@ -12,6 +13,7 @@ $("#p2 .ability").bind("keyup change", function () {
 	autoSetSteely(2, "R");
 	autoSetRuin(2, "R");
 	autoSetCrits($("#p2"), 2);
+	checkNeutralizingGas();
 });
 
 $("#p2 .item").bind("keyup change", function () {
@@ -43,6 +45,10 @@ function autoSetCrits(pokeInfo, i) {
 		let move = moves[moveName] || moves["(No Move)"];
 		moveInfo.children(".move-crit").prop("checked", move.alwaysCrit || (merciless && move.category));
 	}
+}
+
+function checkNeutralizingGas() {
+	isNeutralizingGas = $("#p1").find(".ability").val() === "Neutralizing Gas" || $("#p2").find(".ability").val() === "Neutralizing Gas";
 }
 
 var resultLocations = [[], []];

--- a/_scripts/damage_gen3.js
+++ b/_scripts/damage_gen3.js
@@ -22,8 +22,8 @@ function CALCULATE_MOVES_OF_ATTACKER_ADV(attacker, defender, field) {
 	checkAirLock(defender, field);
 	checkForecast(attacker, field.getWeather());
 	checkForecast(defender, field.getWeather());
-	attacker.stats[SP] = getFinalSpeed(attacker, field.getWeather(), field.getTerrain());
-	defender.stats[SP] = getFinalSpeed(defender, field.getWeather(), field.getTerrain());
+	attacker.stats[SP] = getFinalSpeed(attacker, field.getWeather());
+	defender.stats[SP] = getFinalSpeed(defender, field.getWeather());
 	checkIntimidate(attacker, defender);
 	checkIntimidate(defender, attacker);
 	var defenderSide = field.getSide(~~(mode === "one-vs-all"));

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -404,17 +404,13 @@ function getDamageResult(attacker, defender, move, field) {
 	// Return a bit more info if this is a Parental Bond usage.
 	if (pbDamage.length) {
 		return {
-			"damage": pbDamage.sort(numericSort),
+			"damage": pbDamage.sort((a, b) => a - b),
 			"parentDamage": damage,
 			"childDamage": childDamage,
 			"description": buildDescription(description)
 		};
 	}
-	return {"damage": pbDamage.length ? pbDamage.sort(numericSort) : damage, "description": buildDescription(description)};
-}
-
-function numericSort(a, b) {
-	return a - b;
+	return {"damage": damage, "description": buildDescription(description)};
 }
 
 function calcBP(attacker, defender, move, field, description, ateizeBoost) {

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -727,8 +727,8 @@ function calcBP(attacker, defender, move, field, description, ateizeBoost) {
 
 	let finalBasePower = Math.max(1, pokeRound((basePower * chainMods(bpMods)) / 4096));
 	
-	var excludedExceptions = ["Low Kick", "Flail", "Reversal", "Eruption", "Water Spout", "Gyro Ball", "Fling", "Grass Knot", "Crush Grip", "Heavy Slam", "Electro Ball", "Heat Crash", "Dragon Energy"];
-	if (attacker.isTerastal && moveType === attacker.type1 && finalBasePower < 60 && !move.hasPriority && !move.maxMultiHits && !move.isTwoHit && !move.isThreeHit && !excludedExceptions.includes(move.name)) {
+	// if a move has 1 bp, then it bypasses damage calc or has variable power. Variable power moves do not receive this boost.
+	if (attacker.isTerastal && moveType === attacker.type1 && finalBasePower < 60 && !move.hasPriority && !move.maxMultiHits && !move.isTwoHit && !move.isThreeHit && move.bp != 1) {
 		finalBasePower = 60; // https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9425737
 		description.moveBP = 60;
 	}

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -965,31 +965,26 @@ function modBaseDamage(baseDamage, attacker, defender, move, field, description)
 }
 
 function calcSTABMod(attacker, description) {
-	if (attacker.isTerastal) {
-		if (moveType === attacker.type1) {
-			description.attackerTera = attacker.type1;
-			if (attacker.curAbility === "Adaptability") {
-				description.attackerAbility = attacker.curAbility;
-				return (moveType === attacker.dexType1 || moveType === attacker.dexType2) ? 0x2400 : 0x2000;
-			} else {
-				return (moveType === attacker.dexType1 || moveType === attacker.dexType2) ? 0x2000 : 0x1800;
-			}
-		}
-		else if (moveType === attacker.dexType1 || moveType === attacker.dexType2) {
-			return 0x1800;
-		}
-	} else if (attacker.hasType(moveType)) {
-		if (attacker.curAbility === "Adaptability") {
-			description.attackerAbility = attacker.curAbility;
-			return 0x2000;
-		} else {
-			return 0x1800;
-		}
-	} else if (attacker.curAbility === "Protean" || attacker.curAbility == "Libero") {
+	if (["Protean", "Libero"].includes(attacker.curAbility) && !attacker.isTerastal) {
 		description.attackerAbility = attacker.curAbility;
 		return 0x1800;
 	}
-	return 0x1000;
+	let stabMod = 0x1000;
+	if (attacker.hasType(moveType)) {
+		stabMod += 0x800;
+		if (attacker.isTerastal) {
+			description.attackerTera = attacker.type1;
+		}
+	}
+	if (attacker.isTerastal && (moveType === attacker.dexType1 || moveType === attacker.dexType2)) {
+		stabMod += 0x800;
+	}
+	if (attacker.curAbility === "Adaptability" && attacker.hasType(moveType)) {
+		// this ternary is for when move type matches dex type matches tera type
+		stabMod += stabMod >= 0x2000 ? 0x400 : 0x800;
+		description.attackerAbility = attacker.curAbility;
+	}
+	return stabMod;
 }
 
 function calcFinalMods(attacker, defender, move, field, description, typeEffectiveness, bypassProtect) {

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -359,6 +359,10 @@ function getDamageResult(attacker, defender, move, field) {
 			attacker.boosts[AT] = originalATBoost;
 			attacker.stats[AT] = getModifiedStat(attacker.rawStats[AT], attacker.boosts[AT]);
 		}
+		// temp solution to deal with resist berries on multi-hit moves and provide description
+		if (activateResistBerry(attacker, defender, typeEffectiveness)) {
+			description.defenderItem += " (first hit only)";
+		}
 	}
 	let applyBurn = attacker.status === "Burned" && moveCategory === "Physical" && attacker.curAbility !== "Guts" && !move.ignoresBurn;
 	description.isBurned = applyBurn;
@@ -1047,7 +1051,9 @@ function calcFinalMods(attacker, defender, move, field, description, typeEffecti
 		finalMods.push(0x14CC);
 		description.attackerItem = attacker.item;
 	}
-	if (getBerryResistType(defender.item) === moveType && (typeEffectiveness > 1 || moveType === "Normal") && attacker.curAbility !== "Unnerve" && attacker.ability !== "As One") {
+	if (activateResistBerry(attacker, defender, typeEffectiveness) && !attacker.isChild) {
+		// Do not apply the resist berry to the second Parental Bond hit
+		// Still need to figure out how I want multi-hit moves to handle this interaction
 		finalMods.push(0x800);
 		description.defenderItem = defender.item;
 	}
@@ -1297,6 +1303,10 @@ function killsShedinja(attacker, defender, move, field = {}) {
 	let confusion = ["Confuse Ray", "Flatter", "Supersonic", "Swagger", "Sweet Kiss", "Teeter Dance"].includes(move.name);
 	let otherPassive = (move.name === "Leech Seed" && !defender.hasType("Grass")) || (move.name === "Curse" && attacker.hasType("Ghost"));
 	return weather || poison || burn || dangerItem || confusion || otherPassive;
+}
+
+function activateResistBerry(attacker, defender, typeEffectiveness) {
+	return getBerryResistType(defender.item) === moveType && (typeEffectiveness > 1 || moveType === "Normal") && attacker.curAbility !== "Unnerve" && attacker.ability !== "As One";
 }
 
 function checkAirLock(pokemon, field) {

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -300,6 +300,9 @@ function getDamageResult(attacker, defender, move, field) {
 			return {"damage": [0], "description": buildDescription(description)};
 		}
 	}
+	if (["Burn Up", "Double Shock"].includes(move.name) && !attacker.hasType(moveType)) {
+		return {"damage": [0], "description": buildDescription(description)};
+	}
 	let bypassProtect = ["Doom Desire", "Feint", "Future Sight", "Hyperspace Fury", "Hyperspace Hole", "Phantom Force", "Shadow Force", "Hyper Drill"].includes(move.name) || (attacker.curAbility === "Unseen Fist" && makesContact);
 	if (field.isProtect && !move.isZ && !move.isMax && !bypassProtect) {
 		description.defenderAbility = "Protecting";

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -339,7 +339,7 @@ function getDamageResult(attacker, defender, move, field) {
 
 	let stabMod = calcSTABMod(attacker, description);
 
-	let finalMod = calcFinalMods(attacker, defender, move, field, description, bypassProtect);
+	let finalMod = calcFinalMods(attacker, defender, move, field, description, typeEffectiveness, bypassProtect);
 
 	let damage = [], pbDamage = [];
 	let childDamage;

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -504,6 +504,12 @@ function calcBP(attacker, defender, move, field, description, ateizeBoost) {
 		basePower = (attacker.name === "Ash-Greninja" && attacker.ability === "Battle Bond") ? 20 : move.bp;
 		description.moveBP = basePower;
 		break;
+	case "Grav Apple":
+		if (field.isGravity) {
+			basePower *= 2;
+			description.moveBP = basePower;
+		}
+		break;
 	case "Misty Explosion":
 		basePower *= (field.terrain === "Misty" && attackerGrounded ? 1.5 : 1);
 		description.moveBP = basePower;

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -338,25 +338,23 @@ function getDamageResult(attacker, defender, move, field) {
 
 	let finalMod = calcFinalMods(attacker, defender, move, field, description, bypassProtect);
 
-	var damage = [], pbDamage = [];
-	var child, childDamage;
+	let damage = [], pbDamage = [];
+	let childDamage;
 	if (attacker.curAbility === "Parental Bond" && move.hits === 1 && (field.format === "singles" || !move.isSpread)) {
-		child = JSON.parse(JSON.stringify(attacker));
-		child.rawStats = attacker.rawStats;
-		child.stats = attacker.stats;
-		child.ability = "";
-		child.curAbility = "";
-		child.isChild = true;
-		child.hasType = attacker.hasType;
+		let originalATBoost = attacker.boosts[AT];
 		if (move.name === "Power-Up Punch") {
-			child.boosts[AT] = Math.min(6, child.boosts[AT] + 1);
-			child.stats[AT] = getModifiedStat(child.rawStats[AT], child.boosts[AT]);
+			attacker.boosts[AT] = Math.min(6, attacker.boosts[AT] + 1);
+			attacker.stats[AT] = getModifiedStat(attacker.rawStats[AT], attacker.boosts[AT]);
 		}
-		childDamage = getDamageResult(child, defender, move, field).damage;
+		attacker.curAbility = "";
+		attacker.isChild = true;
+		childDamage = getDamageResult(attacker, defender, move, field).damage;
+		attacker.curAbility = "Parental Bond";
+		attacker.isChild = false;
 		description.attackerAbility = attacker.curAbility;
 		if (move.name === "Power-Up Punch") {
-			child.boosts[AT]--;
-			child.stats[AT] = getModifiedStat(child.rawStats[AT], child.boosts[AT]);
+			attacker.boosts[AT] = originalATBoost;
+			attacker.stats[AT] = getModifiedStat(attacker.rawStats[AT], attacker.boosts[AT]);
 		}
 	}
 	let applyBurn = attacker.status === "Burned" && moveCategory === "Physical" && attacker.curAbility !== "Guts" && !move.ignoresBurn;

--- a/_scripts/game_data/move_data.js
+++ b/_scripts/game_data/move_data.js
@@ -2917,7 +2917,8 @@ var MOVES_BW = $.extend(true, {}, MOVES_DPP, {
 		"bp": 1,
 		"type": "Fire",
 		"category": "Physical",
-		"makesContact": true
+		"makesContact": true,
+		"acc": 100
 	},
 	"Heavy Slam": {
 		"bp": 1,
@@ -4618,14 +4619,6 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"makesContact": true,
 		"isPunch": true,
 		"hasSecondaryEffect": true,
-		"acc": 100
-	},
-	"Heat Crash": {
-		"bp": 1,
-		"acc": 100,
-		"type": "Fire",
-		"category": "Physical",
-		"makesContact": true,
 		"acc": 100
 	},
 	"Dynamax Cannon": {

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -62,13 +62,14 @@ $.fn.dataTableExt.oSort['damage48-desc'] = function (a, b) {
 	return parseInt(b) - parseInt(a);
 };
 
-function MassPokemon(speciesName, setName, autoLevel) {
+function MassPokemon(speciesName, setName) {
 	let pokemon = pokedex[speciesName];
 	let set = setdex[speciesName][setName];
 	let formeNum = getFormeNum(setName, speciesName);
 	if (formeNum != 0) {
 		pokemon = pokedex[pokemon.formes[formeNum]];
 	}
+	let autoLevel = parseInt(localStorage.getItem("autolevelGen" + gen));
 	let massPoke = {
 		"name": speciesName,
 		"setName": setName,
@@ -92,10 +93,15 @@ function MassPokemon(speciesName, setName, autoLevel) {
 		"weight": pokemon.w,
 		"tier": set.tier,
 		"hasType": function (type) { return this.type1 === type || this.type2 === type; },
+		// Reset this mon's stat stages to 0 and clear the stats.
+		// This is used for MassPokemon because the same objects are reused if the gen isn't changed.
 		"revertStats": function () {
 			Object.keys(this.boosts).forEach(stat => { this.boosts[stat] = 0; });
 			this.stats = [];
-		}
+		},
+		// Reset this mon's current ability subject to Neutralizing Gas
+		// This is designed to be called once before calcs and after calcing each move as defender. Do not call this in MassPokemon object creation
+		"resetCurAbility": function () { this.curAbility = (isNeutralizingGas && this.item !== "Ability Shield") ? "" : this.ability }
 	};
 	// maxHP
 	let autoIVs = gen == 4 ? parseInt($("#autoivs-box").val()) : (gen <= 7 ? parseInt($('#autoivs-select').find(":selected").val()) : 31);
@@ -143,11 +149,13 @@ function performCalculations() {
 	var dataSet = [];
 	var userPoke = new Pokemon($("#p1"));
 	userPoke.startingBoosts = [];
+	// after each MassPokemon is calc'd against, reset the user's mon's stat stages to what the user set them to and clear the stats
 	STATS.forEach(stat => { userPoke.startingBoosts[stat] = userPoke.boosts[stat]; });
 	userPoke.revertStats = function () {
 		Object.keys(this.boosts).forEach(stat => { this.boosts[stat] = this.startingBoosts[stat] });
 		this.stats = [];
 	};
+	let userNeutralizingGas = userPoke.ability === "Neutralizing Gas";
 	if (mode === "one-vs-all") {
 		attacker = userPoke;
 	} else {
@@ -171,12 +179,11 @@ function performCalculations() {
 		} else {
 			attacker = setPoke;
 		}
-		if (attacker.ability === "Rivalry") {
-			attacker.gender = "N";
-		}
-		if (defender.ability === "Rivalry") {
-			defender.gender = "N";
-		}
+		// apply Neutralizing Gas if applicable
+		isNeutralizingGas = userNeutralizingGas || setPoke.ability === "Neutralizing Gas";
+		userPoke.resetCurAbility();
+		setPoke.resetCurAbility();
+
 		var damageResults = calculateMovesOfAttacker(attacker, defender, field);
 		var result, minDamage, maxDamage, minPercentage, maxPercentage, minPixels, maxPixels;
 		var highestDamage = -1;
@@ -269,7 +276,6 @@ $(".gen").change(function () {
 	}
 
 	// set up the list of MassPokemon
-	let autoLevel = parseInt(localStorage.getItem("autolevelGen" + gen));
 	let setSpecies = Object.keys(gen == 3 && $("#autolevel-box").val() == 50 ? SETDEX_EM : setdex);
 	setsArray = [];
 	for (let i = 0; i < setSpecies.length; i++) {
@@ -277,7 +283,7 @@ $(".gen").change(function () {
 		let setNames = Object.keys(setdex[speciesName]);
 		for (let j = 0; j < setNames.length; j++) {
 			let setName = setNames[j];
-			setsArray.push(MassPokemon(speciesName, setName, autoLevel));
+			setsArray.push(MassPokemon(speciesName, setName));
 		}
 	}
 });

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -83,7 +83,8 @@ function MassPokemon(speciesName, setName) {
 		"HPEVs": set.evs && typeof set.evs.hp !== "undefined" ? set.evs.hp : 0,
 		"nature": set.nature,
 		"ability": set.ability && typeof set.ability !== "undefined" ? set.ability :
-		(pokemon.ab && typeof pokemon.ab !== "undefined" ? pokemon.ab : ""),
+		(pokemon.ab && typeof pokemon.ab !== "undefined" ? pokemon.ab :
+		(pokemon.abilities && pokemon.abilities.length == 1 ? pokemon.abilities[0] : "")),
 		"item": set.item && typeof set.item !== "undefined" &&
 		(set.item === "Eviolite" || !(set.item.endsWith("ite") && set.item.endsWith("ite X") && set.item.endsWith("ite Y"))) ? set.item : "",
 		"status": "Healthy",

--- a/_scripts/import_custom.js
+++ b/_scripts/import_custom.js
@@ -284,6 +284,9 @@ var savecustom = function () {
 		if (!pokedex[species]) {
 			rejectSet = true;
 			alert("Error: something unexpected happened when parsing " + species + " as a species. Please contact Silver or Eisen with a screenshot including this popup and the calc.");
+		} else if (isFacilitySet(species, spreadName)) {
+			rejectSet = true;
+			alert("Error: " + spreadName + " is already an AI set. Select a different spread name.");
 		} else if (pokedex[species].hasBaseForme) {
 			// This error might pop up if the pokedex has a chain of hasBaseForme longer than 2.
 			rejectSet = true;

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -1037,6 +1037,18 @@ function Side(format, terrain, weather, isAuraFairy, isAuraDark, isAuraBreak, is
 	this.isRuinBeads = isRuinBeads;
 }
 
+// please add the new setdex to this function whenever adding a new gen
+function isFacilitySet(speciesName, setName) {
+	let setdexMaps = [SETDEX_EM, SETDEX_EM_OPEN_LVL, SETDEX_PHGSS, SETDEX_GEN5, SETDEX_GEN6, SETDEX_GEN7, SETDEX_GEN8, SETDEX_GEN80];
+	for (let setdexMap of setdexMaps) {
+		let speciesSets = setdexMap[speciesName];
+		if (speciesSets && (setName in speciesSets)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 const IVS_GEN3 = [31, 21, 18, 15, 12, 9, 6, 3];
 const IVS_OTHER = [31, 27, 23, 19];
 

--- a/index.html
+++ b/index.html
@@ -33,14 +33,14 @@ title: Battle Facilities Calculator
 		</script></div> -->
 	<div class="move-result-group" title="Select a move to show detailed results.">
 		<div class="move-result-subgroup">
-			<div class="result-move-header"><span id="resultHeaderL">Pokemon 1's Moves (select one to show detailed results)</span></div>
+			<!--div class="result-move-header"><span id="resultHeaderL">Pokemon 1's Moves (select one to show detailed results)</span></div-->
 			<div><input class="result-move btn-input" type="radio" name="resultMove" id="resultMoveL1" checked="checked" /><label class="btn btn-xxxwide btn-top" for="resultMoveL1">Hi Jump Kick</label> <span id="resultDamageL1">??? - ???%</span></div>
 			<div><input class="result-move btn-input" type="radio" name="resultMove" id="resultMoveL2" /><label class="btn btn-xxxwide btn-mid" for="resultMoveL2">Falcon Punch</label> <span id="resultDamageL2">??? - ???%</span></div>
 			<div><input class="result-move btn-input" type="radio" name="resultMove" id="resultMoveL3" /><label class="btn btn-xxxwide btn-mid" for="resultMoveL3">Suspicious Odor</label> <span id="resultDamageL3">??? - ???%</span></div>
 			<div><input class="result-move btn-input" type="radio" name="resultMove" id="resultMoveL4" /><label class="btn btn-xxxwide btn-bottom" for="resultMoveL4">Tombstoner</label> <span id="resultDamageL4">??? - ???%</span></div>
 		</div>
 		<div class="move-result-subgroup">
-			<div class="result-move-header"><span id="resultHeaderR">Pokemon 2's Moves (select one to show detailed results)</span></div>
+			<!--div class="result-move-header"><span id="resultHeaderR">Pokemon 2's Moves (select one to show detailed results)</span></div-->
 			<div><input class="result-move btn-input" type="radio" name="resultMove" id="resultMoveR1" /><label class="btn btn-xxxwide btn-top" for="resultMoveR1">Hi Jump Kick</label> <span id="resultDamageR1">??? - ???%</span></div>
 			<div><input class="result-move btn-input" type="radio" name="resultMove" id="resultMoveR2" /><label class="btn btn-xxxwide btn-mid" for="resultMoveR2">Falcon Punch</label> <span id="resultDamageR2">??? - ???%</span></div>
 			<div><input class="result-move btn-input" type="radio" name="resultMove" id="resultMoveR3" /><label class="btn btn-xxxwide btn-mid" for="resultMoveR3">Suspicious Odor</label> <span id="resultDamageR3">??? - ???%</span></div>
@@ -48,8 +48,8 @@ title: Battle Facilities Calculator
 		</div>
 	</div>
 	<div class="main-result-group">
-		<div class="big-text" title="Click to copy result">
-			<span id="mainResult">Loading...</span>
+		<div class="big-text">
+			<span id="mainResult" title="Click to copy result">Loading...</span>
 			<span id="afterAcc"></span>
 		</div>
 		<div class="small-text"><span id="damageValues">(If you see this message for more than a few seconds, try enabling JavaScript. If you have that enabled, try deleting your cookies. Otherwise, I won't be able to help you unless you send a screenshot of your browser console.)</span></div>


### PR DESCRIPTION
- Several fixes for Parental Bond accuracy
   - Power-Up Punch now calcs correctly in the mass calc.
   - Resist berries only count the first hit.
- Implemented Neutralizing Gas, which included reworking how abilities are handled across the calc.
- Implemented Burn Up and Double Shock.
- Implemented Grav Apple.
- General code clean up and bug fixes.
   - Included in this is splitting the modern damage calc into functions so it's a bit cleaner.