### PR TITLE
Update terrain and weather

### DIFF
--- a/_scripts/ap_calc.js
+++ b/_scripts/ap_calc.js
@@ -1,6 +1,7 @@
 $("#p1 .ability").bind("keyup change", function () {
 	autoSetCrits($("#p1"), 1);
 	checkNeutralizingGas();
+	curAbilities[0] = $(this).val();
 });
 
 $("#p1 .status").bind("keyup change", function () {
@@ -8,12 +9,13 @@ $("#p1 .status").bind("keyup change", function () {
 });
 
 $("#p2 .ability").bind("keyup change", function () {
-	autosetWeather($(this).val(), 1);
+	autoSetWeatherTerrain(curAbilities[1], $(this).val(), curAbilities[0]);
 	autoSetVicStar(2, "R");
 	autoSetSteely(2, "R");
 	autoSetRuin(2, "R");
 	autoSetCrits($("#p2"), 2);
 	checkNeutralizingGas();
+	curAbilities[1] = $(this).val();
 });
 
 $("#p2 .item").bind("keyup change", function () {

--- a/_scripts/ap_calc.js
+++ b/_scripts/ap_calc.js
@@ -9,13 +9,14 @@ $("#p1 .status").bind("keyup change", function () {
 });
 
 $("#p2 .ability").bind("keyup change", function () {
-	autoSetWeatherTerrain(curAbilities[1], $(this).val(), curAbilities[0]);
-	autoSetVicStar(2, "R");
-	autoSetSteely(2, "R");
-	autoSetRuin(2, "R");
+	let ability = $(this).val();
+	autoSetWeatherTerrain(curAbilities[1], ability, curAbilities[0]);
+	autoSetVicStar(ability, "R");
+	autoSetSteely(ability, "R");
+	autoSetRuin(ability, "R");
 	autoSetCrits($("#p2"), 2);
 	checkNeutralizingGas();
-	curAbilities[1] = $(this).val();
+	curAbilities[1] = ability;
 });
 
 $("#p2 .item").bind("keyup change", function () {

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -293,6 +293,10 @@ function setNewFieldEffect(effectType, currentAbility, newAbility, opponentAbili
 		newEffect = effectAbilities[newAbility];
 	}
 	// check if need to switch to the opponent's effect
+	else if (effectAbilities[currentAbility] !== currentEffect) {
+		// don't change to the opponent's effect if this mon's old ability doesn't match the current effect
+		return;
+	}
 	else if (opponentAbility in effectAbilities) {
 		newEffect = effectAbilities[opponentAbility];
 	}

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -23,13 +23,6 @@ function attachValidation(clazz, min, max) {
 function validate(obj, min, max) {
 	obj.val(Math.max(min, Math.min(max, ~~obj.val())));
 }
-function clampIntRange(num, min, max) {
-	if (typeof num !== "number") num = 0;
-	num = Math.floor(num);
-	if (min !== undefined && num < min) num = min;
-	if (max !== undefined && num > max) num = max;
-	return num;
-}
 
 $(".max").bind("keyup change", function () {
 	var poke = $(this).closest(".poke-info");
@@ -624,7 +617,7 @@ $(".forme").change(function () {
 	//}
 });
 
-function getTerrainEffects() {
+/*function getTerrainEffects() {
 	var className = $(this).prop("className");
 	className = className.substring(0, className.indexOf(" "));
 	switch (className) {
@@ -656,7 +649,7 @@ function getTerrainEffects() {
 		}
 		break;
 	}
-}
+}*/
 
 function isGroundedTerrain(pokeInfo) {
 	return $("#gravity").prop("checked") || pokeInfo.find(".type1").val() !== "Flying" && pokeInfo.find(".type2").val() !== "Flying" &&
@@ -1364,7 +1357,7 @@ $(document).ready(function () {
 		$("#gen9").prop("checked", true);
 		$("#gen9").change();
 	}
-	$(".terrain-trigger").bind("change keyup", getTerrainEffects);
+	//$(".terrain-trigger").bind("change keyup", getTerrainEffects);
 	//$(".calc-trigger").bind("change keyup", calculate);
 	$(".set-selector").select2({
 		"formatResult": function (object) {

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -216,10 +216,11 @@ $(".ability").bind("keyup change", function () {
 });
 
 $("#p1 .ability").bind("keyup change", function () {
-	autoSetWeatherTerrain(curAbilities[0], $(this).val(), $("#p2") ? curAbilities[1] : "");
-	autoSetVicStar(1, "L");
-	autoSetSteely(1, "L");
-	autoSetRuin(1, "L");
+	let ability = $(this).val();
+	autoSetWeatherTerrain(curAbilities[0], ability, $("#p2") ? curAbilities[1] : "");
+	autoSetVicStar(ability, "L");
+	autoSetSteely(ability, "L");
+	autoSetRuin(ability, "L");
 	// Do not set curAbility here. This bind executes before the one in ap_calc
 });
 
@@ -240,11 +241,12 @@ function autoSetAura() {
 		$("input:checkbox[id='aura-break']").prop("checked", lastAura[2]);
 }
 
-function autoSetVicStar(i, side) {
-	var ability = $("#p" + i + " .ability").val();
+function autoSetVicStar(ability, side) {
 	$("input:checkbox[id='vicStar" + side + "']").prop("checked", (!isNeutralizingGas && ability === "Victory Star"));
 }
 
+// Right now this is only getting used by weather/terrain setting since it's the only thing that cares about the previous ability.
+// Other functions could use this since it's global, but it would complicate things since curAbilities can only be updated after weather/terrain autoset.
 var curAbilities = ["", ""];
 var manuallySetWeather = "";
 var manuallySetTerrain = "";
@@ -281,11 +283,11 @@ var autoTerrainAbilities = {
 };
 
 function autoSetWeatherTerrain(currentAbility, newAbility, opponentAbility) {
-	let newWeather = getNewFieldEffect("weather", currentAbility, newAbility, opponentAbility, manuallySetWeather, autoWeatherAbilities);
-	let newTerrain = getNewFieldEffect("terrain", currentAbility, newAbility, opponentAbility, manuallySetTerrain, autoTerrainAbilities);
+	let newWeather = setNewFieldEffect("weather", currentAbility, newAbility, opponentAbility, manuallySetWeather, autoWeatherAbilities);
+	let newTerrain = setNewFieldEffect("terrain", currentAbility, newAbility, opponentAbility, manuallySetTerrain, autoTerrainAbilities);
 }
 
-function getNewFieldEffect(effectType, currentAbility, newAbility, opponentAbility, manuallySetEffect, effectAbilities) {
+function setNewFieldEffect(effectType, currentAbility, newAbility, opponentAbility, manuallySetEffect, effectAbilities) {
 	let currentEffect = $("input:radio[name='" + effectType + "']:checked").val();
 	let newEffect = manuallySetEffect;
 	// check if setting a new effect
@@ -337,13 +339,11 @@ function autosetStatus(p, item) {
 	}
 }
 
-function autoSetSteely(i, side) {
-	var ability = $("#p" + i + " .ability").val();
+function autoSetSteely(ability, side) {
 	$("input:checkbox[id='steelySpirit" + side + "']").prop("checked", (!isNeutralizingGas && ability === "Steely Spirit"));
 }
 
-function autoSetRuin(i, side) {
-	var ability = $("#p" + i + " .ability").val();
+function autoSetRuin(ability, side) {
 	$("input:checkbox[id='ruinTablets" + side + "']").prop("checked", (!isNeutralizingGas && ability === "Tablets of Ruin"));
 	$("input:checkbox[id='ruinVessel" + side + "']").prop("checked", (!isNeutralizingGas && ability === "Vessel of Ruin"));
 	$("input:checkbox[id='ruinSword" + side + "']").prop("checked", (!isNeutralizingGas && ability === "Sword of Ruin"));


### PR DESCRIPTION
- The weather and terrain code got a rewrite, making terrain a lot "stickier" than it was before. Terrain will now interact with abilities the same way weather does, and it will no longer be removed whenever any ability changes.
- Misty and Electric terrain will no longer interact with status and no longer block status menu options. The old implementation did not work perfectly, and I would prefer that users are able to account for circumstances where a mon is unaffected by terrain, or status'd before it entered terrain.