### PR TITLE
Implement paralysis and abilities

### DIFF
--- a/_scripts/ap_calc.js
+++ b/_scripts/ap_calc.js
@@ -137,7 +137,7 @@ function setUpRecoilRecoveryText(result, attacker, defender, move, minDamage, ma
 	let defMaxHP = defender.maxHP;
 	// percentage-based recoil and healing use normal rounding for their final value in gens 5+.
 	let roundFunc = gen <= 4 ? x => Math.floor(x) : x => Math.round(x);
-	if (typeof move.hasRecoil === "number" && minDamage > 0) {
+	if (typeof move.hasRecoil === "number" && minDamage > 0 && (attacker.ability !== "Rock Head" || isNeutralizingGas)) {
 		result.recoilType = "recoil";
 		// Parental Bond adds the damage values into a total and then applies the recoil value, so this is fine
 		minRecoilDamage = Math.max(roundFunc(Math.min(minDamage, defCurHP) * move.hasRecoil), 1);
@@ -221,7 +221,7 @@ function setUpRecoilRecoveryText(result, attacker, defender, move, minDamage, ma
 			maxHealthRecovered = Math.max(maxHealthRecovered, 1);
 		}
 
-		if (defender.ability === "Liquid Ooze") {
+		if (defender.ability === "Liquid Ooze" && !isNeutralizingGas) {
 			result.recoilType = defender.ability;
 			result.recoilRange = minHealthRecovered;
 			result.recoilPercent = Math.round(minHealthRecovered * 1000 / atkMaxHP) / 10;

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -1251,13 +1251,18 @@ function getFinalSpeed(pokemon, weather, terrain) {
 		speed = Math.floor(speed / 2);
 	}
 	
+	if (pokemon.status === "Paralyzed" && pokemon.curAbility !== "Quick Feet") {
+		speed = Math.floor(speed / (gen <= 6 ? 4 : 2));
+	}
+
 	if (pokemon.curAbility === "Chlorophyll" && weather.indexOf("Sun") > -1 && pokemon.item !== "Utility Umbrella" ||
 		pokemon.curAbility === "Sand Rush" && weather === "Sand" ||
 		pokemon.curAbility === "Swift Swim" && weather.indexOf("Rain") > -1 && pokemon.item !== "Utility Umbrella" ||
 		pokemon.curAbility === "Slush Rush" && (weather.indexOf("Hail") > -1 || weather === "Snow") ||
 		pokemon.curAbility === "Surge Surfer" && terrain === "Electric") {
 		speed *= 2;
-	} else if (checkProtoQuarkHighest(pokemon, weather, terrain) === SP) {
+	} else if (checkProtoQuarkHighest(pokemon, weather, terrain) === SP ||
+		pokemon.curAbility === "Quick Feet" && pokemon.status !== "Healthy") {
 		speed = Math.floor(speed * 1.5);
 	}
 	return speed;

--- a/_scripts/game_data/ability_data.js
+++ b/_scripts/game_data/ability_data.js
@@ -99,6 +99,7 @@ var ABILITIES_DPP = ABILITIES_ADV.concat([
 	"No Guard",
 	"Normalize",
 	"Poison Heal",
+	"Quick Feet",
 	"Reckless",
 	"Rivalry",
 	"Scrappy",

--- a/_scripts/game_data/ability_data.js
+++ b/_scripts/game_data/ability_data.js
@@ -44,6 +44,7 @@ var ABILITIES_ADV = [
 	"Pressure",
 	"Pure Power",
 	"Rain Dish",
+	"Rock Head",
 	"Rough Skin",
 	"Sand Stream",
 	"Sand Veil",

--- a/_scripts/game_data/move_data.js
+++ b/_scripts/game_data/move_data.js
@@ -4811,6 +4811,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
 		"bp": 140,
 		"type": "Steel",
 		"category": "Special",
+		"hasRecoil": true,
 		"acc": 95
 	},
 	"Stuff Cheeks": {

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -457,12 +457,19 @@ function getFinalSpeedHonk() {
 	} else if (item === "Macho Brace" || item === "Iron Ball") {
 		speed = Math.floor(speed / 2);
 	}
+
+	if ($(".status").val() === "Paralyzed" && ability !== "Quick Feet") {
+		speed = Math.floor(speed / (gen <= 6 ? 4 : 2));
+	}
+
 	if (ability === "Chlorophyll" && weather.indexOf("Sun") > -1 && item !== "Utility Umbrella" ||
 		ability === "Sand Rush" && weather === "Sand" ||
 		ability === "Swift Swim" && weather.indexOf("Rain") > -1 && item !== "Utility Umbrella" ||
 		ability === "Slush Rush" && (weather.indexOf("Hail") > -1 || weather === "Snow") ||
 		ability === "Surge Surfer" && terrain === "Electric") {
 		speed *= 2;
+	} else if (ability === "Quick Feet" && $(".status").val() !== "Healthy") {
+		speed = Math.floor(speed * 1.5);
 	}
 	$(".totalMod").text(speed);
 }


### PR DESCRIPTION
- Paralysis is now implemented in the calc, which means that it now affects the final speed number shown to the player and can now factor into speed-based calculations.
- Rock Head and Quick Feet have been implemented.

Previously undocumented change:
- Analytic has been changed to always apply its boost to the Pokemon with it, so it now requires users to properly apply it. The only thing this affects are two BDSP sets, since that's the only time that  the calc will auto-load Analytic for Pokemon with that ability (aside from user sets).