### PR TITLE
Tweaks

### DIFF
--- a/_scripts/ap_calc.js
+++ b/_scripts/ap_calc.js
@@ -169,7 +169,7 @@ function setDamageText(result, attacker, defender, move, fieldSide, resultLocati
 	// firstHitMap is the same as assembledDamageMap, but with resist berry applied if applicable. On multi hit moves the berry only applies to the first strike of the multihit.
 	// firstHitMap is the basis for the ranges and percentages displayed for the user, and is the same as assembledDamageMap if there is no resist berry.
 	let assembledDamageMap = getAssembledDamageMap(result, resultDamageMap, moveHits);
-	let firstHitMap = result.hasOwnProperty('resistBerryDamage') ? getAssembledDamageMap(result, resultDamageMap, moveHits, true) : new Map(assembledDamageMap);
+	let firstHitMap = result.firstHitDamage ? getAssembledDamageMap(result, resultDamageMap, moveHits, true) : new Map(assembledDamageMap);
 
 	// put together the primary hit information based on the first hit map
 	let sortedDamageValues = Array.from(firstHitMap.keys());
@@ -183,14 +183,14 @@ function setDamageText(result, attacker, defender, move, fieldSide, resultLocati
 		}
 
 		if (result.childDamage) {
-			result.hitDamageValues = "(First hit: " + (result.resistBerryDamage ? result.resistBerryDamage : result.damage).join(", ") +
+			result.hitDamageValues = "(First hit: " + (result.firstHitDamage ? result.firstHitDamage : result.damage).join(", ") +
 			"; Second hit: " + result.childDamage.join(", ") + ")";
 		} else if (result.tripleAxelDamage) {
-			result.hitDamageValues = "(First hit: " + (result.resistBerryDamage ? result.resistBerryDamage : result.tripleAxelDamage[0]).join(", ") +
+			result.hitDamageValues = "(First hit: " + (result.firstHitDamage ? result.firstHitDamage : result.tripleAxelDamage[0]).join(", ") +
 			"; Second hit: " + result.tripleAxelDamage[1].join(", ") +
 			(moveHits > 2 ? "; Third hit: " + result.tripleAxelDamage[2].join(", ") : "") + ")";
-		} else if (result.resistBerryDamage) {
-			result.hitDamageValues = "(First hit: " + result.resistBerryDamage.join(", ") + "; Other hits: " + result.damage.join(", ") + ")";
+		} else if (result.firstHitDamage) {
+			result.hitDamageValues = "(First hit: " + result.firstHitDamage.join(", ") + "; Other hits: " + result.damage.join(", ") + ")";
 		} else {
 			result.hitDamageValues = "(" + result.damage.join(", ") + ")";
 		}
@@ -198,7 +198,7 @@ function setDamageText(result, attacker, defender, move, fieldSide, resultLocati
 
 	// damageMap numbers use integral numbers, except in this if statement.
 	// To avoid exceeding Number.MAX_SAFE_INTEGER (2 ** 53 - 1) and avoid needing BigNums, divide all values by the same factor
-	// Since damage maps are (currently) only used for the first 4 hits when calcing an NHKO, dividing all values by (mapCombinations / 8192) works.
+	// Since damage maps are (currently) only used for the first 4 hits when calcing an nHKO, dividing all values by (mapCombinations / (2 ** 13)) works.
 	if (mapCombinations > MAP_SQUASH_CONSTANT) {
 		squashDamageMap(firstHitMap, mapCombinations);
 		mapCombinations = squashDamageMap(assembledDamageMap, mapCombinations);

--- a/_scripts/damage_gen4.js
+++ b/_scripts/damage_gen4.js
@@ -442,7 +442,7 @@ function getDamageResultPtHGSS(attacker, defender, move, field) {
 		description.attackerAbility = attacker.ability;
 	}
 	var berryMod = 1;
-	if (allowResistBerry && getBerryResistType(defender.item) === moveType && (typeEffectiveness > 1 || moveType === "Normal") && attacker.ability !== "Unnerve") {
+	if (allowOneTimeReducers && getBerryResistType(defender.item) === moveType && (typeEffectiveness > 1 || moveType === "Normal") && attacker.ability !== "Unnerve") {
 		berryMod = 0.5;
 		description.defenderItem = defender.item;
 	}
@@ -463,10 +463,10 @@ function getDamageResultPtHGSS(attacker, defender, move, field) {
 
 	if (berryMod != 1) {
 		// this branch actually calculates the damage without the resist berry
-		result.resistBerryDamage = damage;
-		allowResistBerry = false;
+		result.firstHitDamage = damage;
+		allowOneTimeReducers = false;
 		result.damage = getDamageResultPtHGSS(attacker, defender, move, field).damage;
-		allowResistBerry = true;
+		allowOneTimeReducers = true;
 	}
 
 	return result;

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -682,7 +682,8 @@ function calcBP(attacker, defender, move, field, description, ateizeBoost) {
 		defender.item.endsWith("Plate") && defender.name.startsWith("Arceus") ||
 		defender.item.endsWith("Memory") && defender.name.startsWith("Silvally") ||
 		defender.item.endsWith(" Z") ||
-		defender.item === "Booster Energy" && (defender.ability === "Protosynthesis" || defender.ability === "Quark Drive"))) {
+		defender.item === "Booster Energy" && (defender.ability === "Protosynthesis" || defender.ability === "Quark Drive") ||
+		defender.item.endsWith("Mask") && defender.name.startsWith("Ogerpon-"))) {
 		// Mega Stones, Red/Blue Orbs, and Rusted items are already accounted for by the fact that they don't exist as items
 		bpMods.push(0x1800);
 		description.moveBP = move.bp * 1.5;

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -86,7 +86,7 @@ function CALCULATE_MOVES_OF_ATTACKER_MODERN(attacker, defender, field) {
 var moveType, moveCategory, makesContact, isCritical;
 var attackerGrounded, defenderGrounded;
 var originalSABoost;
-var allowResistBerry = true;
+var allowOneTimeReducers = true;
 function getDamageResult(attacker, defender, move, field) {
 	var moveDescName = move.name;
 
@@ -362,17 +362,18 @@ function getDamageResult(attacker, defender, move, field) {
 			attacker.stats[AT] = getModifiedStat(attacker.rawStats[AT], attacker.boosts[AT]);
 		}
 		description.attackerAbility = attacker.curAbility;
-		allowResistBerry = false;
+		allowOneTimeReducers = false;
 		attacker.isChild = true;
 		result.childDamage = getDamageResult(attacker, defender, move, field).damage;
-		allowResistBerry = true;
+		allowOneTimeReducers = true;
 		attacker.isChild = false;
 		if (move.name === "Power-Up Punch") {
 			attacker.boosts[AT] = originalATBoost;
 			attacker.stats[AT] = getModifiedStat(attacker.rawStats[AT], attacker.boosts[AT]);
 		}
-		if (activateResistBerry(attacker, defender, typeEffectiveness)) {
-			result.resistBerryDamage = damage;
+		if (activateResistBerry(attacker, defender, typeEffectiveness) ||
+			((defender.curAbility === "Multiscale" || (defender.ability == "Shadow Shield" && !isNeutralizingGas)) && defender.curHP === defender.maxHP)) {
+			result.firstHitDamage = damage;
 		}
 	}
 
@@ -380,9 +381,9 @@ function getDamageResult(attacker, defender, move, field) {
 		// tripleAxelDamage is an array of damage arrays; a 2D number array
 		result.tripleAxelDamage = [];
 		let startingBP = move.bp;
-		allowResistBerry = false;
+		allowOneTimeReducers = false;
 		let finalModNoBerry = calcFinalMods(attacker, defender, move, field, {}, typeEffectiveness, bypassProtect);
-		allowResistBerry = true;
+		allowOneTimeReducers = true;
 		for (let hitNum = 1; hitNum <= move.hits; hitNum++) {
 			move.bp = startingBP * hitNum;
 			finalBasePower = calcBP(attacker, defender, move, field, {});
@@ -392,12 +393,14 @@ function getDamageResult(attacker, defender, move, field) {
 		move.bp = startingBP;
 	}
 
-	if (allowResistBerry && activateResistBerry(attacker, defender, typeEffectiveness)) {
-		// this branch actually calculates the damage without the resist berry
-		result.resistBerryDamage = damage;
-		allowResistBerry = false;
+	if (allowOneTimeReducers && (
+		activateResistBerry(attacker, defender, typeEffectiveness) ||
+		((defender.curAbility === "Multiscale" || (defender.ability == "Shadow Shield" && !isNeutralizingGas)) && defender.curHP === defender.maxHP))) {
+		// this branch actually calculates the damage without the one-time reducers
+		result.firstHitDamage = damage;
+		allowOneTimeReducers = false;
 		finalMod = calcFinalMods(attacker, defender, move, field, {}, typeEffectiveness, bypassProtect);
-		allowResistBerry = true;
+		allowOneTimeReducers = true;
 		result.damage = calcDamageRange(baseDamage, stabMod, typeEffectiveness, applyBurn, finalMod);
 	}
 
@@ -1014,7 +1017,7 @@ function calcFinalMods(attacker, defender, move, field, description, typeEffecti
 		finalMods.push(0x2000);
 		description.attackerAbility = attacker.curAbility;
 	}
-	if (((defender.curAbility === "Multiscale" || (defender.ability == "Shadow Shield" && !isNeutralizingGas)) && defender.curHP === defender.maxHP) ||
+	if ((allowOneTimeReducers && (defender.curAbility === "Multiscale" || (defender.ability == "Shadow Shield" && !isNeutralizingGas)) && defender.curHP === defender.maxHP) ||
 		defender.curAbility === "Fluffy" && makesContact ||
 		defender.curAbility === "Punk Rock" && move.isSound ||
 		defender.curAbility === "Ice Scales" && moveCategory === "Special") {
@@ -1040,7 +1043,7 @@ function calcFinalMods(attacker, defender, move, field, description, typeEffecti
 		finalMods.push(0x14CC);
 		description.attackerItem = attacker.item;
 	}
-	if (allowResistBerry && activateResistBerry(attacker, defender, typeEffectiveness)) {
+	if (allowOneTimeReducers && activateResistBerry(attacker, defender, typeEffectiveness)) {
 		if (attacker.curAbility === "Ripen") {
 			finalMods.push(0x400);
 			description.attackerAbility = attacker.curAbility;

--- a/_scripts/game_data/setdex_gen3_sets.js
+++ b/_scripts/game_data/setdex_gen3_sets.js
@@ -10030,7 +10030,7 @@ SETDEX_EM = {
       "tier": "50"
     },
     "Shuckle (Lucy Silver)": {
-      "evs": {
+      "evs": { // this is not a mistake: https://github.com/DizzyEggg/pokeemerald/blob/ec89e519f912618e9168d8a616ed85c35cb6d966/src/frontier_util.c#L401C48
         "hp": 252,
         "sa": 106,
         "sd": 252

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -198,7 +198,7 @@ function performCalculations() {
 				let resultDamageMap = mapFromArray(result.damage);
 				let moveHits = result.childDamage ? 2 : attackerMove.hits; // this is placeholder.
 				let assembledDamageMap = getAssembledDamageMap(result, resultDamageMap, moveHits);
-				let firstHitMap = result.hasOwnProperty('resistBerryDamage') ? getAssembledDamageMap(result, resultDamageMap, moveHits, true) : new Map(assembledDamageMap);
+				let firstHitMap = result.firstHitDamage ? getAssembledDamageMap(result, resultDamageMap, moveHits, true) : new Map(assembledDamageMap);
 				let mapCombinations = result.damage.length ** moveHits;
 				if (mapCombinations > MAP_SQUASH_CONSTANT) { // see comment in ap_calc
 					squashDamageMap(firstHitMap, mapCombinations);

--- a/_scripts/ko_chance.js
+++ b/_scripts/ko_chance.js
@@ -92,6 +92,7 @@ function setKOChanceText(result, move, moveHits, attacker, defender, field, dama
 		setResultText(result, 1, moveAccuracy, false, mapCombinations, hazardText, "");
 		return;
 	} else if (checkHPThreshold(targetHP + berryRecovery, 0, firstHitMin, maxHP)) {
+		// since there was not a KO from the first condition, this KO is only guaranteed by eot damage
 		setResultText(result, 1, moveAccuracy, false, mapCombinations, hazardText.concat(eotText), berryText);
 		return;
 	} else if (firstHitMax >= targetHP || checkHPThreshold(targetHP + berryRecovery, 0, firstHitMax, maxHP)) {
@@ -104,7 +105,8 @@ function setKOChanceText(result, move, moveHits, attacker, defender, field, dama
 				break;
 			}
 		}
-		setResultText(result, 1, moveAccuracy, koCombinations, mapCombinations, hazardText.concat(eotText), berryText);
+		// this is checking hits that bypass berry recovery, so no berryText
+		setResultText(result, 1, moveAccuracy, koCombinations, mapCombinations, hazardText.concat(eotText), "");
 		return;
 	}
 	// since no OHKO occured, set up nHitDamageMap and berryDamageMap
@@ -396,9 +398,6 @@ function calculateNHKO(upperHitCount, targetHP, maxHP, damageMap, nHitDamageMap,
 }
 
 function toxicSum(counter, maxHP) {
-	if (counter == 0) {
-		return 0;
-	}
 	let sum = 0;
 	for (let i = counter; i > 0; i--) {
 		sum += Math.floor(maxHP * counter / 16);
@@ -407,7 +406,7 @@ function toxicSum(counter, maxHP) {
 }
 
 function powerDivision(numerator, divisor, power) {
-	// simple implementation of calculation of something of the form: numerator / (divisor ** power)
+	// naive implementation of calculation of something of the form: numerator / (divisor ** power)
 	// This is done this way to avoid issues with large numbers. This algorithm is fine since power will always be less than 10.
 	while (power > 0) {
 		power--;

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -1181,27 +1181,27 @@ function squashDamageMap(damageMap, mapCombinations) {
 	return mapCombinations / divisor;
 }
 
-function getAssembledDamageMap(result, resultDamageMap, moveHits, considerResistBerry) {
+function getAssembledDamageMap(result, resultDamageMap, moveHits, considerReducedDamage) {
 	if (result.damage.length == 1) {
 		//result.hitDamageValues = "(" + result.damage[0] + ")";
 		return new Map([[result.damage[0], 1]]);
 	} else if (result.tripleAxelDamage) {
 		// result.tripleAxelDamage[0] goes unused, it should be the non-resist berry first hit.
-		let assembledDamageMap = combineDamageMaps((considerResistBerry ? mapFromArray(result.resistBerryDamage) : resultDamageMap), mapFromArray(result.tripleAxelDamage[1]));
+		let assembledDamageMap = combineDamageMaps((considerReducedDamage ? mapFromArray(result.firstHitDamage) : resultDamageMap), mapFromArray(result.tripleAxelDamage[1]));
 		if (moveHits == 3) {
 			return combineDamageMaps(assembledDamageMap, mapFromArray(result.tripleAxelDamage[2]));
 		}
 		return assembledDamageMap;
 	} else if (result.childDamage) {
-		return combineDamageMaps((considerResistBerry ? mapFromArray(result.resistBerryDamage) : resultDamageMap), mapFromArray(result.childDamage));
+		return combineDamageMaps((considerReducedDamage ? mapFromArray(result.firstHitDamage) : resultDamageMap), mapFromArray(result.childDamage));
 	} else if (moveHits > 1) {
-		if (considerResistBerry) {
-			return combineDamageMaps(recurseDamageMaps(resultDamageMap, moveHits - 1), mapFromArray(result.resistBerryDamage));
+		if (considerReducedDamage) {
+			return combineDamageMaps(recurseDamageMaps(resultDamageMap, moveHits - 1), mapFromArray(result.firstHitDamage));
 		}
 		return recurseDamageMaps(resultDamageMap, moveHits);
 	}
 
-	return considerResistBerry ? mapFromArray(result.resistBerryDamage) : resultDamageMap;
+	return considerReducedDamage ? mapFromArray(result.firstHitDamage) : resultDamageMap;
 }
 // End damage map functions
 


### PR DESCRIPTION
Bug fixes and tweaks:
 - Multiscale now only applies to the first hit when considering multihit moves and the listed chance to KO.
 - Recovery berries will no longer print to the description for non-guaranteed OHKOs.
 - Knock Off is no longer boosted against Ogerpon with a Mask.