### PR TITLE
The Indigo Disk Update

### DIFF
--- a/_scripts/game_data/ability_data.js
+++ b/_scripts/game_data/ability_data.js
@@ -310,5 +310,6 @@ var ABILITIES_SV = ABILITIES_SS.concat([
 	"Wind Rider",
 	"Zero to Hero",
 	"Mind's Eye",
-	"Embody Aspect"
+	"Embody Aspect",
+	"Tera Shell"
 ]);

--- a/_scripts/game_data/move_data.js
+++ b/_scripts/game_data/move_data.js
@@ -5658,6 +5658,12 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 		"category": "Special",
 		"acc": 100
 	},
+	"Ivy Cudgel": {
+		"bp": 100,
+		"type": "Grass",
+		"category": "Physical",
+		"acc": 100
+	},
 	"Matcha Gotcha": {
 		"bp": 80,
 		"type": "Grass",
@@ -5673,10 +5679,92 @@ var MOVES_SV = $.extend(true, {}, MOVES_SS, {
 		"isBullet": true,
 		"acc": 85
 	},
-	"Ivy Cudgel": {
-		"bp": 100,
-		"type": "Grass",
+
+	"Alluring Voice": {
+		"bp": 80,
+		"type": "Fairy",
+		"category": "Special",
+		"hasSecondaryEffect": true,
+		"acc": 100
+	},
+	"Electro Shot": {
+		"bp": 130,
+		"type": "Electric",
+		"category": "Special",
+		"acc": 100
+	},
+	"Fickle Beam": {
+		"bp": 80,
+		"type": "Dragon",
+		"category": "Special",
+		"acc": 100
+	},
+	"Hard Press": {
+		"bp": 1,
+		"type": "Steel",
 		"category": "Physical",
+		"acc": 100
+	},
+	"Malignant Chain": {
+		"bp": 100,
+		"type": "Poison",
+		"category": "Special",
+		"hasSecondaryEffect": true,
+		"acc": 100
+	},
+	"Mighty Cleave": {
+		"bp": 95,
+		"type": "Rock",
+		"category": "Physical",
+		"bypassesProtect": true,
+		"acc": 100
+	},
+	"Psychic Noise": {
+		"bp": 75,
+		"type": "Psychic",
+		"category": "Special",
+		"hasSecondaryEffect": true,
+		"acc": 100
+	},
+	"Supercell Slam": {
+		"bp": 100,
+		"type": "Electric",
+		"category": "Physical",
+		"hasRecoil": "crash",
+		"acc": 95
+	},
+	"Tachyon Cutter": {
+		"bp": 50,
+		"type": "Steel",
+		"category": "Special",
+		"isTwoHit": true,
+		"acc": 101
+	},
+	"Temper Flare": {
+		"bp": 75,
+		"type": "Fire",
+		"category": "Physical",
+		"acc": 100
+	},
+	"Tera Starstorm": {
+		"bp": 120,
+		"type": "Normal",
+		"category": "Special",
+		"acc": 100
+	},
+	"Thunderclap": {
+		"bp": 70,
+		"type": "Electric",
+		"category": "Special",
+		"hasPriority": true,
+		"acc": 100
+	},
+	"Upper Hand": {
+		"bp": 65,
+		"type": "Fighting",
+		"category": "Physical",
+		"hasPriority": true,
+		"hasSecondaryEffect": true,
 		"acc": 100
 	}
 });

--- a/_scripts/game_data/pokedex.js
+++ b/_scripts/game_data/pokedex.js
@@ -18233,6 +18233,133 @@ var POKEDEX_SV = $.extend(true, {}, POKEDEX_SS, {
 		},
 		"w": 39.8,
 		"abilities": ["Sturdy"]
+	},
+
+	"Archaludon": {
+		"t1": "Steel",
+		"t2": "Dragon",
+		"bs": {
+			"hp": 90,
+			"at": 105,
+			"df": 130,
+			"sa": 125,
+			"sd": 65,
+			"sp": 85
+		},
+		"w": 60,
+		"abilities": ["Stamina", "Sturdy", "Stalwart"]
+	},
+	"Hydrapple": {
+		"t1": "Grass",
+		"t2": "Dragon",
+		"bs": {
+			"hp": 106,
+			"at": 80,
+			"df": 110,
+			"sa": 120,
+			"sd": 80,
+			"sp": 44
+		},
+		"w": 93,
+		"abilities": ["Supersweet Syrup", "Regenerator", "Sticky Hold"]
+	},
+	"Gouging Fire": {
+		"t1": "Fire",
+		"t2": "Dragon",
+		"bs": {
+			"hp": 105,
+			"at": 115,
+			"df": 121,
+			"sa": 65,
+			"sd": 93,
+			"sp": 91
+		},
+		"w": 590,
+		"abilities": ["Protosynthesis"]
+	},
+	"Raging Bolt": {
+		"t1": "Electric",
+		"t2": "Dragon",
+		"bs": {
+			"hp": 125,
+			"at": 73,
+			"df": 91,
+			"sa": 137,
+			"sd": 89,
+			"sp": 75
+		},
+		"w": 480,
+		"abilities": ["Protosynthesis"]
+	},
+	"Iron Boulder": {
+		"t1": "Rock",
+		"t2": "Psychic",
+		"bs": {
+			"hp": 90,
+			"at": 120,
+			"df": 80,
+			"sa": 68,
+			"sd": 108,
+			"sp": 124
+		},
+		"w": 162.5,
+		"abilities": ["Quark Drive"]
+	},
+	"Iron Crown": {
+		"t1": "Steel",
+		"t2": "Psychic",
+		"bs": {
+			"hp": 90,
+			"at": 72,
+			"df": 100,
+			"sa": 122,
+			"sd": 108,
+			"sp": 98
+		},
+		"w": 156,
+		"abilities": ["Quark Drive"]
+	},
+	"Terapagos-Terastal": {
+		"t1": "Normal",
+		"bs": {
+			"hp": 95,
+			"at": 95,
+			"df": 110,
+			"sa": 105,
+			"sd": 110,
+			"sp": 85
+		},
+		"w": 16,
+		"abilities": ["Tera Shell"],
+		"formes": [ "Terapagos-Terastal", "Terapagos-Stellar"]
+	},
+	"Terapagos-Stellar": {
+		"t1": "Normal",
+		"bs": {
+			"hp": 160,
+			"at": 105,
+			"df": 110,
+			"sa": 130,
+			"sd": 110,
+			"sp": 85
+		},
+		"w": 77,
+		"abilities": ["Teraform Zero"],
+		"hasBaseForme": "Terapagos-Terastal"
+	},
+	"Pecharunt": {
+		"t1": "Poison",
+		"t2": "Ghost",
+		"bs": {
+			"hp": 88,
+			"at": 88,
+			"df": 160,
+			"sa": 88,
+			"sd": 88,
+			"sp": 88
+		},
+		"w": 77,
+		"abilities": ["Poison Puppeteer"]
 	}
 });
 


### PR DESCRIPTION
Implemented the new Pokemon, moves, and abilities from The Indigo Disk.
   - implemented Archaludon, Hydrapple, Gouging Fire, Raging Bolt, Iron Boulder, Iron Crown, Terapagos-Terastal, Terapagos-Stellar, and Pecharunt.
      - Teragapos changes between its formes depending on Terastallization.
   - implemented Electro Shot, Tera Starstorm, Fickle Beam, Thunderclap, Mighty Cleave, Tachyon Cutter, Hard Press, Alluring Voice, Temper Flare, Supercell Slam, Psychic Noise, Upper Hand, and Malignant Chain.
   - implemented Tera Shell.
   - updated the Pokedex.

Implemented new Stellar Terastallization mechanics.
   - when terastallized to the Stellar type, all moves gain STAB.
   - Stellar-type Tera Blast has been updated to become super-effective against Terastallized defenders.

Fixed a bug where Pokemon that use the forme system and the formes have a different type (i.e. Zacian) did not apply STAB correctly while Terastallized.
Fixed Ripen.

There will likely be very minor details that need to be adjusted, otherwise this update should be correct.