### PR TITLE
Custom sets top selector dropdown

### DIFF
--- a/_scripts/damage_gen3.js
+++ b/_scripts/damage_gen3.js
@@ -145,7 +145,7 @@ function getDamageResultADV(attacker, defender, move, field) {
             (!isPhysical && attacker.item === "Soul Dew" && (attacker.name === "Latios" || attacker.name === "Latias"))) {
 		at = Math.floor(at * 1.5);
 		description.attackerItem = attacker.item;
-	} else if ((!isPhysical && attacker.item === "Deep Sea Tooth" && attacker.name === "Clamperl") ||
+	} else if ((!isPhysical && attacker.item.replaceAll(" ", "") === "DeepSeaTooth" && attacker.name === "Clamperl") ||
             (!isPhysical && attacker.item === "Light Ball" && attacker.name === "Pikachu") ||
             (isPhysical && attacker.item === "Thick Club" && (attacker.name === "Cubone" || attacker.name === "Marowak"))) {
 		at *= 2;
@@ -155,7 +155,7 @@ function getDamageResultADV(attacker, defender, move, field) {
 	if (!isPhysical && defender.item === "Soul Dew" && (defender.name === "Latios" || defender.name === "Latias")) {
 		df = Math.floor(df * 1.5);
 		description.defenderItem = defender.item;
-	} else if ((!isPhysical && defender.item === "Deep Sea Scale" && defender.name === "Clamperl") ||
+	} else if ((!isPhysical && defender.item.replaceAll(" ", "") === "DeepSeaScale" && defender.name === "Clamperl") ||
             (isPhysical && defender.item === "Metal Powder" && defender.name === "Ditto")) {
 		df *= 2;
 		description.defenderItem = defender.item;

--- a/_scripts/damage_gen4.js
+++ b/_scripts/damage_gen4.js
@@ -294,7 +294,7 @@ function getDamageResultPtHGSS(attacker, defender, move, field) {
 		description.attackerItem = attacker.item;
 	} else if ((attacker.item === "Light Ball" && attacker.name === "Pikachu") ||
             (attacker.item === "Thick Club" && (attacker.name === "Cubone" || attacker.name === "Marowak") && isPhysical) ||
-            (attacker.item === "Deep Sea Tooth" && attacker.name === "Clamperl" && !isPhysical)) {
+            (attacker.item.replaceAll(" ", "") === "DeepSeaTooth" && attacker.name === "Clamperl" && !isPhysical)) {
 		attack *= 2;
 		description.attackerItem = attacker.item;
 	}
@@ -335,7 +335,7 @@ function getDamageResultPtHGSS(attacker, defender, move, field) {
 	if (defender.item === "Soul Dew" && (defender.name === "Latios" || defender.name === "Latias") && !isPhysical) {
 		defense = Math.floor(defense * 1.5);
 		description.defenderItem = defender.item;
-	} else if ((defender.item === "Deep Sea Scale" && defender.name === "Clamperl" && !isPhysical) ||
+	} else if ((defender.item.replaceAll(" ", "") === "DeepSeaScale" && defender.name === "Clamperl" && !isPhysical) ||
             (defender.item === "Metal Powder" && defender.name === "Ditto" && isPhysical)) {
 		defense *= 2;
 		description.defenderItem = defender.item;

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -181,7 +181,9 @@ function getDamageResult(attacker, defender, move, field) {
 	case "Meteor Beam":
 	case "Electro Shot":
 		originalSABoost = attacker.boosts[SA];
-		attacker.boosts[SA] = attacker.curAbility === "Simple" ? Math.min(6, attacker.boosts[SA] + 2) : (attacker.curAbility === "Contrary" && attacker.item !== "White Herb" ? Math.max(-6, attacker.boosts[SA] - 1) : Math.min(6, attacker.boosts[SA] + 1));
+		attacker.boosts[SA] = attacker.curAbility === "Simple" ? Math.min(6, attacker.boosts[SA] + 2) :
+			(attacker.curAbility === "Contrary" && attacker.item !== "White Herb" ? Math.max(-6, attacker.boosts[SA] - 1) :
+				Math.min(6, attacker.boosts[SA] + 1));
 		attacker.stats[SA] = getModifiedStat(attacker.rawStats[SA], attacker.boosts[SA]);
 		// this boost gets reset after the attack stat is calc'd
 		break;
@@ -899,7 +901,7 @@ function calcAtk(attacker, defender, move, field, description) {
 		atMods.push(0x1800);
 		description.attackerItem = attacker.item;
 	} else if (attacker.item === "Thick Club" && (attacker.name === "Cubone" || attacker.name === "Marowak" || attacker.name === "Marowak-Alola") && moveCategory === "Physical" ||
-		attacker.item === "Deep Sea Tooth" && attacker.name === "Clamperl" && moveCategory === "Special" ||
+		attacker.item.replaceAll(" ", "") === "DeepSeaTooth" && attacker.name === "Clamperl" && moveCategory === "Special" ||
 		attacker.item === "Light Ball" && attacker.name === "Pikachu" && !move.isZ) {
 		atMods.push(0x2000);
 		description.attackerItem = attacker.item;
@@ -968,7 +970,7 @@ function calcDef(attacker, defender, move, field, description) {
 		description.defenderItem = defender.item;
 	}
 
-	if (defender.item === "Deep Sea Scale" && defender.name === "Clamperl" && !hitsPhysical ||
+	if (defender.item.replaceAll(" ", "") === "DeepSeaScale" && defender.name === "Clamperl" && !hitsPhysical ||
 		defender.item === "Metal Powder" && defender.name === "Ditto" && hitsPhysical) {
 		dfMods.push(0x2000);
 		description.defenderItem = defender.item;

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -1430,7 +1430,7 @@ function getSetOptions() {
 		if (pokeName in setdex) {
 			for (setName in setdex[pokeName]) {
 				setOptions.push({
-					"pokemon": pokeName,
+					"pokemon": pokeName, // string used in searches
 					"set": setName, // string that displays in the dropdown list
 					"text": pokeName + " (" + setName + ")", // string that displays in the selector
 					"id": pokeName + " (" + setName + ")"
@@ -1457,7 +1457,7 @@ function getSetOptions() {
 
 	if (customSetOptions.length > 0) {
 		customSetOptions.sort((a, b) => a.set < b.set ? -1 : (a.set > b.set ? 1 : 0));
-		setOptions = [{"pokemon": "Custom Sets", "text": "Custom Sets"}, ...customSetOptions, ...setOptions];
+		setOptions = [{"pokemon": "", "text": "Custom Sets"}, ...customSetOptions, ...setOptions];
 	}
 
 	return setOptions;

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -1416,39 +1416,32 @@ function clearField() {
 }
 
 function getSetOptions() {
-	var pokeNames, index;
-	pokeNames = Object.keys(pokedex);
-	index = pokeNames.length;
-	while (index--) {
-		if (pokedex[pokeNames[index]].hasBaseForme) {
-			pokeNames.splice(index, 1);
+	let setOptions = [];
+	let customSetOptions = [];
+	Object.keys(pokedex).sort().forEach(function(pokeName) {
+		if (pokedex[pokeName].hasBaseForme) {
+			return;
 		}
-	}
-	pokeNames.sort();
-	index = pokeNames.length;
-	while (index--) { //forcing alolan forms to show first
-		if (pokeNames[index].includes("-Alola")) {
-			var temp = pokeNames[index];
-			pokeNames.splice(index, 1); //deleting alolan entry
-			var regularForm = temp.substring(0, temp.indexOf("-Alola"));
-			var regularIndex = pokeNames.indexOf(regularForm);
-			pokeNames.splice(regularIndex, 0, temp); //re-inserting it right before non-alolan entry
-		}
-	}
-	var setOptions = [];
-	for (var i = 0; i < pokeNames.length; i++) {
-		var pokeName = pokeNames[i];
-		setOptions.push({
+
+		setOptions.push({ // bold species header, will be unselectable
 			"pokemon": pokeName,
 			"text": pokeName
 		});
-		if (pokeName in setdexAll) {
-			var setNames = Object.keys(setdexAll[pokeName]);
-			for (var j = 0; j < setNames.length; j++) {
-				var setName = setNames[j];
+		if (pokeName in setdex) {
+			for (setName in setdex[pokeName]) {
 				setOptions.push({
 					"pokemon": pokeName,
-					"set": setName,
+					"set": setName, // string that displays in the dropdown list
+					"text": pokeName + " (" + setName + ")", // string that displays in the selector
+					"id": pokeName + " (" + setName + ")"
+				});
+			}
+		}
+		if (pokeName in SETDEX_CUSTOM) {
+			for (setName in SETDEX_CUSTOM[pokeName]) {
+				customSetOptions.push({
+					"pokemon": pokeName,
+					"set": pokeName + " (" + setName + ")",
 					"text": pokeName + " (" + setName + ")",
 					"id": pokeName + " (" + setName + ")"
 				});
@@ -1460,7 +1453,13 @@ function getSetOptions() {
 			"text": pokeName + " (Blank Set)",
 			"id": pokeName + " (Blank Set)"
 		});
+	});
+
+	if (customSetOptions.length > 0) {
+		customSetOptions.sort((a, b) => a.set < b.set ? -1 : (a.set > b.set ? 1 : 0));
+		setOptions = [{"pokemon": "Custom Sets", "text": "Custom Sets"}, ...customSetOptions, ...setOptions];
 	}
+
 	return setOptions;
 }
 


### PR DESCRIPTION
- Custom sets now prepend to the set selector dropdown. They no longer appear under each species. They could though.
- Deep Sea Scale and Tooth now work correctly in gens 3-5

Previously undocumented change:
- Custom move BP now properly updates for the power calculation.