### PR TITLE
OHKO Counter

### DIFF
--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -515,7 +515,7 @@ function calcBP(attacker, defender, move, field, description, ateizeBoost) {
 		description.moveBP = basePower;
 		break;
 	case "Weather Ball":
-		basePower *= (field.weather !== "" && attacker.item !== "Utility Umbrella") ? 2 : 1;
+		basePower *= (field.weather !== "" && !((field.weather.endsWith("Sun") || field.weather.endsWith("Rain")) && attacker.item === "Utility Umbrella")) ? 2 : 1;
 		description.moveBP = basePower;
 		break;
 	case "Terrain Pulse":

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -1215,7 +1215,7 @@ function buildDescription(description) {
 	}
 	output = appendIfSet(output, description.HPEVs);
 	if (description.defenseEVs) {
-		output += " / " + description.defenseEVs + " ";
+		output += "/ " + description.defenseEVs + " ";
 	}
 	output = appendIfSet(output, description.defenderItem);
 	output = appendIfSet(output, description.defenderAbility);

--- a/_scripts/game_data/item_data.js
+++ b/_scripts/game_data/item_data.js
@@ -201,7 +201,10 @@ var ITEMS_SM = ITEMS_XY.concat([
 	"Grassy Seed"
 ]);
 
+// Big Nugget is 130 Fling BP without the side effects of Heavy Ball.
+// It also consolidates Overheat and Leaf Storm TR items.
 var ITEMS_SS = ITEMS_SM.concat([
+	"Big Nugget",
 	"Blunder Policy",
 	"Eject Pack",
 	"Heavy-Duty Boots",
@@ -416,18 +419,52 @@ function getBerryResistType(berry) {
 }
 
 function getFlingPower(item) {
-	return item === "Iron Ball" ? 130 :
-		item === "Hard Stone" ? 100 :
-			item.indexOf("Plate") !== -1 || ["Deep Sea Tooth", "Thick Club"].indexOf(item) !== -1 ? 90 :
-				["Assault Vest", "Weakness Policy"].indexOf(item) !== -1 ? 80 :
-					["Poison Barb", "Dragon Fang"].indexOf(item) !== -1 ? 70 :
-						["Adamant Orb", "Lustrous Orb", "Macho Brace", "Stick"].indexOf(item) !== -1 ? 60 :
-							item === "Sharp Beak" ? 50 :
-								item === "Eviolite" ? 40 :
-									["Black Belt", "Black Sludge", "Black Glasses", "Charcoal", "Deep Sea Scale", "Flame Orb", "King's Rock",
-										"Life Orb", "Light Ball", "Magnet", "Metal Coat", "Miracle Seed", "Mystic Water", "Never-Melt Ice",
-										"Razor Fang", "Soul Dew", "Spell Tag", "Toxic Orb", "Twisted Spoon"].indexOf(item) !== -1 ? 30 :
-										10;
+	if (item.includes("Plate")) {
+		return 90;
+	}
+	switch (item) {
+		case "Iron Ball":
+		case "Big Nugget":
+			return 130;
+		case "Hard Stone":
+		case "Room Service":
+			return 100;
+		case "DeepSeaTooth":
+		case "Deep Sea Tooth":
+		case "Grip Claw":
+		case "Thick Club":
+			return 90;
+		case "Assault Vest":
+		case "Blunder Policy":
+		case "Heavy-Duty Boots":
+		case "Quick Claw":
+		case "Razor Claw":
+		case "Safety Goggles":
+		case "Sticky Barb":
+		case "Weakness Policy":
+			return 80;
+		case "Dragon Fang":
+		case "Poison Barb":
+			return 70;
+		case "Adamant Orb":
+		case "Damp Rock":
+		case "Griseous Orb":
+		case "Heat Rock":
+		case "Leek":
+		case "Lustrous Orb":
+		case "Macho Brace":
+		case "Rocky Helmet":
+		case "Terrain Extender":
+		case "Utility Umbrella":
+			return 60;
+		case "Toxic Orb":
+		case "Flame Orb":
+		case "Light Ball":
+		case "King's Rock":
+		case "Razor Fang":
+			return 30;
+	}
+	return 10;
 }
 
 function getNaturalGift(item) {

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -204,50 +204,43 @@ function performCalculations() {
 			userPoke.resetCurAbility();
 			setPoke.resetCurAbility();
 
-			var damageResults = calculateMovesOfAttacker(attacker, defender, field);
-			var result, minDamage, maxDamage, minPercentage, maxPercentage, minPixels, maxPixels;
-			var highestDamage = -1;
-			var data = [setName];
+			let damageResults = calculateMovesOfAttacker(attacker, defender, field);
+			let result;
+			let maxDamage;
+			let highestDamage = 0;
+			let highestN = 0;
+			let data = { setName: setName, move: "(No Move)", percentRange: "0 - 0%", koChance: "nice move" };
+			if (mode === "one-vs-all") {
+				data.type1 = defender.type1;
+				data.type2 = defender.type2 ? defender.type2 : "";
+			} else {
+				data.type1 = attacker.type1;
+				data.type2 = attacker.type2 ? attacker.type2 : "";
+			}
 			for (let n = 0; n < 4; n++) {
 				result = damageResults[n];
-				attackerMove = attacker.moves[n];
-				let resultDamageMap = mapFromArray(result.damage);
-				let moveHits = result.childDamage ? 2 : attackerMove.hits; // this is placeholder.
-				let assembledDamageMap = getAssembledDamageMap(result, resultDamageMap, moveHits);
-				let firstHitMap = result.firstHitDamage ? getAssembledDamageMap(result, resultDamageMap, moveHits, true) : new Map(assembledDamageMap);
-				let mapCombinations = result.damage.length ** moveHits;
-				if (mapCombinations > MAP_SQUASH_CONSTANT) { // see comment in ap_calc
-					squashDamageMap(firstHitMap, mapCombinations);
-					mapCombinations = squashDamageMap(assembledDamageMap, mapCombinations);
-				}
-				let sortedDamageValues = Array.from(firstHitMap.keys());
-				sortedDamageValues.sort((a, b) => a - b);
-				minDamage = sortedDamageValues[0];
-				maxDamage = sortedDamageValues[sortedDamageValues.length - 1];
-				// If any piece of the calculation is a string and not a number ie. Pokemon.level, stats will concatinate into strings, and the below will eval to 0.
-				// I want to be very sure that everything is using the correct types, so I want this behavior. Shoutouts to writing code w/o tests.
-				minPercentage = Math.round(minDamage * 1000 / defender.maxHP) / 10;
-				maxPercentage = Math.round(maxDamage * 1000 / defender.maxHP) / 10;
+				let moveHits = result.childDamage ? 2 : attacker.moves[n].hits; // this is placeholder.
+				maxDamage = moveHits * (result.firstHitDamage ? result.firstHitDamage[result.firstHitDamage - 1] : result.damage[result.damage.length - 1]);
 				if (maxDamage > highestDamage) {
 					highestDamage = maxDamage;
-					while (data.length > 1) {
-						data.pop();
-					}
-					data.push(highestDamage <= 0 ? "(No Move)" : attackerMove.name.replace("Hidden Power", "HP"));
-					data.push(minPercentage + " - " + maxPercentage + "%");
-					//setKOChanceText(result, attackerMove, attacker, defender, field.getSide(~~(mode === "one-vs-all")));
-					setKOChanceText(result, attackerMove, moveHits, attacker, defender, field.getSide(~~(mode === "one-vs-all")), assembledDamageMap, mapCombinations, firstHitMap, sortedDamageValues);
-					if (attackerMove.bp === 0) {
-						data.push("nice move");
-					} else {
-						data.push(result.koChanceText ? result.koChanceText : "Did not get koChanceText");
-					}
+					highestN = n;
 				}
 			}
-			data.push((mode === "one-vs-all") ? defender.type1 : attacker.type1);
-			data.push(((mode === "one-vs-all") ? defender.type2 : attacker.type2) || "");
-			dataSet.push(data);
+			if (highestDamage) {
+				result = damageResults[highestN];
+				let move = attacker.moves[highestN];
+				let moveHits = result.childDamage ? 2 : move.hits; // this is placeholder.
+				let mainDamageInfo = DamageInfo(result, moveHits);
+				let firstHitDamageInfo = result.firstHitDamage ? DamageInfo(result, moveHits, true) : mainDamageInfo;
+				setKOChanceText(result, move, moveHits, attacker, defender, field.getSide(~~(mode === "one-vs-all")), mainDamageInfo, firstHitDamageInfo);
+				data.koChance = result.koChanceText ? result.koChanceText : "Did not get koChanceText";
+				let minPercentage = Math.round(firstHitDamageInfo.min * 1000 / defender.maxHP) / 10;
+				let maxPercentage = Math.round(firstHitDamageInfo.max * 1000 / defender.maxHP) / 10;
+				data.percentRange = minPercentage + " - " + maxPercentage + "%";
+				data.move = move.name.replace("Hidden Power", "HP");
+			}
 
+			dataSet.push(data);
 			// fields in the boosts and stats objects should be the only things that get changed in the Pokemon object during mass calc
 			attacker.revertStats();
 			defender.revertStats();
@@ -340,19 +333,18 @@ function constructDataTable() {
 	table = $("#holder-2").DataTable({
 		destroy: true,
 		columnDefs: [
-			{ // remove the type columns
-				targets: [4, 5],
-				visible: false,
-				searchable: false
-			},
-			{
-				targets: [2],
-				type: 'damage100'
-			},
 			{ // Sort KO Chance by damage% instead
-				targets: [3],
-				iDataSort: 2
+				"orderData": [2], // percentRange = col 2
+				"targets": 3 // koChance = col 3
 			}
+		],
+		columns: [
+			{ data: 'setName' },
+			{ data: "move" },
+			{ data: 'percentRange', type: "damage100" }, // type specifies that this column is sorted via the damage100 functions
+			{ data: 'koChance' },
+			{ data: 'type1', visible: false, searchable: false },
+			{ data: 'type2', visible: false, searchable: false }
 		],
 		dom: 'frti',
 		/*colVis: { The options that allows selection of which columns to include in the table

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -178,6 +178,7 @@ function performCalculations() {
 	var startingWeather = field.getWeather();
 
 	let setSpecies = Object.keys(setdex);
+	let ohkoCount = 0;
 	for (let speciesName of setSpecies) {
 		let setNames = Object.keys(setdex[speciesName]);
 		for (let setName of setNames) {
@@ -220,7 +221,7 @@ function performCalculations() {
 			for (let n = 0; n < 4; n++) {
 				result = damageResults[n];
 				let moveHits = result.childDamage ? 2 : attacker.moves[n].hits; // this is placeholder.
-				maxDamage = moveHits * (result.firstHitDamage ? result.firstHitDamage[result.firstHitDamage - 1] : result.damage[result.damage.length - 1]);
+				maxDamage = moveHits * (result.firstHitDamage ? result.firstHitDamage[result.firstHitDamage.length - 1] : result.damage[result.damage.length - 1]);
 				if (maxDamage > highestDamage) {
 					highestDamage = maxDamage;
 					highestN = n;
@@ -238,6 +239,10 @@ function performCalculations() {
 				let maxPercentage = Math.round(firstHitDamageInfo.max * 1000 / defender.maxHP) / 10;
 				data.percentRange = minPercentage + " - " + maxPercentage + "%";
 				data.move = move.name.replace("Hidden Power", "HP");
+				// let setKOChanceText() do the math of whether something got the OHKO after hazards etc.
+				if (data.koChance === "guaranteed OHKO") {
+					ohkoCount++;
+				}
 			}
 
 			dataSet.push(data);
@@ -249,7 +254,7 @@ function performCalculations() {
 		}
 	}
 	table.rows.add(dataSet).draw();
-	return dataSet.length;
+	return { setsCount: dataSet.length, ohkoCount: ohkoCount };
 }
 
 function getSelectedTier() {
@@ -293,6 +298,7 @@ $(".gen").change(function () {
 		break;
 	}
 	$(defaultChecked).prop("checked", true);
+	$("#ohkoCounter").text("");
 	if ($.fn.DataTable.isDataTable("#holder-2")) {
 		table.clear();
 		constructDataTable();
@@ -370,10 +376,11 @@ function placeBsBtn() {
 	$("#holder-2_wrapper").prepend(honkalculator);
 	$("#honkalculate").click(function () {
 		table.clear();
-		var startTime = performance.now();
-		var setCount = performCalculations();
-		var endTime = performance.now();
-		console.log("honkalculated " + setCount + " sets in " + Math.round(endTime - startTime) + "ms");
+		let startTime = performance.now();
+		let massCalcInfo = performCalculations();
+		let endTime = performance.now();
+		console.log("honkalculated " + massCalcInfo.setsCount + " sets in " + Math.round(endTime - startTime) + "ms");
+		$("#ohkoCounter").text("OHKOs: " + Math.round(massCalcInfo.ohkoCount * 100 / massCalcInfo.setsCount) + "% (" + massCalcInfo.ohkoCount + "/" + massCalcInfo.setsCount + ")");
 	});
 }
 

--- a/honkalculate.html
+++ b/honkalculate.html
@@ -685,7 +685,10 @@ title: Battle Facilities Mass Calculator
     <div><!--Start Damage Results panel-->
         <fieldset class="panel holder-0" style="min-width:845px">
             <div class="panel-heading">
-                <h4 class="panel-title">Damage Results</h4>
+                <h4 class="panel-title">
+                    Damage Results
+                    <div class="panel-title" id="ohkoCounter" style="float: right"></div>
+                </h4>
             </div>
             <table class="hide display" id="holder-2">
                 <thead>


### PR DESCRIPTION
- The mass calc counts how many OHKOs occur for each mass calc now, displaying both a percentage and raw numbers.
- Fling was updated to cover more cases. All facility sets that use Fling are accounted for now, as well as most conceivable uses.
- Refactoring of several areas
   - the mass calc table now populates from an array of objects instead of an array of arrays.
   - objects now encapsulate the damage maps to store some additional meta information.