### PR TITLE
More checkbox abilities

### DIFF
--- a/_scripts/damage_gen3.js
+++ b/_scripts/damage_gen3.js
@@ -170,22 +170,21 @@ function getDamageResultADV(attacker, defender, move, field) {
 	if (defender.ability === "Thick Fat" && (moveType === "Fire" || moveType === "Ice")) {
 		at = Math.floor(at / 2);
 		description.defenderAbility = defender.ability;
-	} else if (isPhysical && defender.ability === "Marvel Scale" && defender.status !== "Healthy") {
+	} else if (isPhysical && defender.ability === "Marvel Scale" && (defender.status !== "Healthy" || defender.isAbilityActivated)) {
 		df = Math.floor(df * 1.5);
 		description.defenderAbility = defender.ability;
 	}
 
-	if (isPhysical && (attacker.ability === "Hustle" || (attacker.ability === "Guts" && attacker.status !== "Healthy"))) {
+	if (isPhysical && (attacker.ability === "Hustle" || (attacker.ability === "Guts" && (attacker.status !== "Healthy" || attacker.isAbilityActivated)))) {
 		at = Math.floor(at * 1.5);
 		description.attackerAbility = attacker.ability;
 	} else if (!isPhysical && (attacker.ability === "Plus" || attacker.ability === "Minus") && attacker.isAbilityActivated) {
 		at = Math.floor(at * 1.5);
 		description.attackerAbility = attacker.ability;
-	} else if (attacker.curHP <= attacker.maxHP / 3 &&
-            ((attacker.ability === "Overgrow" && moveType === "Grass") ||
-            (attacker.ability === "Blaze" && moveType === "Fire") ||
-            (attacker.ability === "Torrent" && moveType === "Water") ||
-            (attacker.ability === "Swarm" && moveType === "Bug"))) {
+	} else if (((attacker.curAbility === "Overgrow" && moveType === "Grass" ||
+        attacker.curAbility === "Blaze" && moveType === "Fire" ||
+        attacker.curAbility === "Torrent" && moveType === "Water" ||
+        attacker.curAbility === "Swarm" && moveType === "Bug") && (attacker.curHP <= attacker.maxHP / 3 || attacker.isAbilityActivated))) {
 		basePower = Math.floor(basePower * 1.5);
 		description.attackerAbility = attacker.ability;
 	}

--- a/_scripts/damage_gen4.js
+++ b/_scripts/damage_gen4.js
@@ -245,15 +245,14 @@ function getDamageResultPtHGSS(attacker, defender, move, field) {
 	}
 
 	if ((attacker.ability === "Reckless" && move.hasRecoil) ||
-            (attacker.ability === "Iron Fist" && move.isPunch)) {
+        (attacker.ability === "Iron Fist" && move.isPunch)) {
 		basePower = Math.floor(basePower * 1.2);
 		description.attackerAbility = attacker.ability;
-	} else if ((attacker.curHP <= attacker.maxHP / 3 &&
-            ((attacker.ability === "Overgrow" && moveType === "Grass") ||
-            (attacker.ability === "Blaze" && moveType === "Fire") ||
-            (attacker.ability === "Torrent" && moveType === "Water") ||
-            (attacker.ability === "Swarm" && moveType === "Bug"))) ||
-            (attacker.ability === "Technician" && basePower <= 60 && move.name !== "Struggle")) {
+	} else if (((attacker.curAbility === "Overgrow" && moveType === "Grass" ||
+        attacker.curAbility === "Blaze" && moveType === "Fire" ||
+        attacker.curAbility === "Torrent" && moveType === "Water" ||
+        attacker.curAbility === "Swarm" && moveType === "Bug") && (attacker.curHP <= attacker.maxHP / 3 || attacker.isAbilityActivated)) ||
+        attacker.ability === "Technician" && basePower <= 60 && move.name !== "Struggle") {
 		basePower = Math.floor(basePower * 1.5);
 		description.attackerAbility = attacker.ability;
 	}
@@ -298,7 +297,7 @@ function getDamageResultPtHGSS(attacker, defender, move, field) {
 		attack = Math.floor(attack * 1.5);
 		description.attackerAbility = attacker.ability;
 		description.weather = field.weather;
-	} else if (isPhysical && (attacker.ability === "Hustle" || (attacker.ability === "Guts" && attacker.status !== "Healthy"))) {
+	} else if (isPhysical && (attacker.ability === "Hustle" || (attacker.ability === "Guts" && (attacker.status !== "Healthy" || attacker.isAbilityActivated)))) {
 		attack = Math.floor(attack * 1.5);
 		description.attackerAbility = attacker.ability;
 	} else if (!isPhysical && (attacker.ability === "Plus" || attacker.ability === "Minus") && attacker.isAbilityActivated) {
@@ -341,7 +340,7 @@ function getDamageResultPtHGSS(attacker, defender, move, field) {
 		description.defenseBoost = defenseBoost;
 	}
 
-	if (defender.curAbility === "Marvel Scale" && defender.status !== "Healthy" && isPhysical) {
+	if (defender.curAbility === "Marvel Scale" && (defender.status !== "Healthy" || defender.isAbilityActivated) && isPhysical) {
 		defense = Math.floor(defense * 1.5);
 		description.defenderAbility = defender.curAbility;
 	} else if (defender.curAbility === "Flower Gift" && field.weather === "Sun" && !isPhysical) {

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -764,10 +764,10 @@ function calcBP(attacker, defender, move, field, description, ateizeBoost) {
 		description.isHelpingHand = true;
 	}
 
-	if (field.isCharge && moveType === "Electric") {
+	if (moveType === "Electric" && (field.isCharge || (["Electromorphosis", "Wind Power"].includes(attacker.curAbility) && attacker.isAbilityActivated))) {
 		bpMods.push(0x2000);
-		if (["Electromorphosis", "Wind Power"].includes(attacker.ability)) {
-			description.attackerAbility = attacker.ability;
+		if (["Electromorphosis", "Wind Power"].includes(attacker.curAbility)) {
+			description.attackerAbility = attacker.curAbility;
 		} else {
 			description.isCharge = true;
 		}
@@ -861,11 +861,11 @@ function calcAtk(attacker, defender, move, field, description) {
 		atMods.push(0x1800);
 		description.attackerAbility = attacker.curAbility;
 		description.weather = field.weather;
-	} else if (attacker.curAbility === "Guts" && attacker.status !== "Healthy" && moveCategory === "Physical" ||
-		attacker.curAbility === "Overgrow" && attacker.curHP <= attacker.maxHP / 3 && moveType === "Grass" ||
-		attacker.curAbility === "Blaze" && attacker.curHP <= attacker.maxHP / 3 && moveType === "Fire" ||
-		attacker.curAbility === "Torrent" && attacker.curHP <= attacker.maxHP / 3 && moveType === "Water" ||
-		attacker.curAbility === "Swarm" && attacker.curHP <= attacker.maxHP / 3 && moveType === "Bug" ||
+	} else if (attacker.curAbility === "Guts" && moveCategory === "Physical" && (attacker.status !== "Healthy" || attacker.isAbilityActivated) ||
+		((attacker.curAbility === "Overgrow" && moveType === "Grass" ||
+		attacker.curAbility === "Blaze" && moveType === "Fire" ||
+		attacker.curAbility === "Torrent" && moveType === "Water" ||
+		attacker.curAbility === "Swarm" && moveType === "Bug") && (attacker.curHP <= attacker.maxHP / 3 || attacker.isAbilityActivated)) ||
 		attacker.curAbility === "Steelworker" && moveType === "Steel" ||
 		attacker.curAbility === "Gorilla Tactics" && moveCategory === "Physical" && !attacker.isDynamax ||
 		attacker.curAbility === "Transistor" && gen <= 8 && moveType === "Electric" ||
@@ -948,7 +948,7 @@ function calcDef(attacker, defender, move, field, description) {
 		description.defenderAbility = defender.curAbility;
 		description.weather = field.weather;
 	}
-	if (defender.curAbility === "Marvel Scale" && defender.status !== "Healthy" && hitsPhysical ||
+	if (defender.curAbility === "Marvel Scale" && (defender.status !== "Healthy" || defender.isAbilityActivated) && hitsPhysical ||
 		defender.curAbility === "Grass Pelt" && field.terrain === "Grassy" && hitsPhysical) {
 		dfMods.push(0x1800);
 		description.defenderAbility = defender.curAbility;
@@ -1366,7 +1366,7 @@ function getFinalSpeed(pokemon, weather, terrain) {
 		pokemon.curAbility === "Surge Surfer" && terrain === "Electric") {
 		speed *= 2;
 	} else if (checkProtoQuarkHighest(pokemon, weather, terrain) === SP ||
-		pokemon.curAbility === "Quick Feet" && pokemon.status !== "Healthy") {
+		pokemon.curAbility === "Quick Feet" && (pokemon.status !== "Healthy" || pokemon.isAbilityActivated)) {
 		speed = Math.floor(speed * 1.5);
 	}
 	return speed;

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -443,11 +443,7 @@ function setLevel(lvl) {
 }
 
 $(".set-selector").change(function (e) {
-	var genWasChanged;
 	var format = getSelectedTier();
-	if (genWasChanged) {
-		genWasChanged = false;
-	}
 });
 
 function calcDTDimensions() {
@@ -463,6 +459,10 @@ function calcDTDimensions() {
 function getBottomOffset(obj) {
 	return obj.offset().top + obj.outerHeight();
 }
+
+$(".isActivated").bind("change", function () {
+	getFinalSpeedHonk();
+});
 
 function getFinalSpeedHonk() {
 	var speed = getModifiedStat($(".sp .total").text(), $(".sp .boost").val());
@@ -493,7 +493,7 @@ function getFinalSpeedHonk() {
 		ability === "Slush Rush" && (weather.indexOf("Hail") > -1 || weather === "Snow") ||
 		ability === "Surge Surfer" && terrain === "Electric") {
 		speed *= 2;
-	} else if (ability === "Quick Feet" && $(".status").val() !== "Healthy") {
+	} else if (ability === "Quick Feet" && ($(".status").val() !== "Healthy" || $(".isActivated").prop("checked"))) {
 		speed = Math.floor(speed * 1.5);
 	}
 	$(".totalMod").text(speed);

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -92,7 +92,6 @@ function MassPokemon(speciesName, setName) {
 		"ability": set.ability && typeof set.ability !== "undefined" ? set.ability :
 		(pokemon.ab && typeof pokemon.ab !== "undefined" ? pokemon.ab :
 		(pokemon.abilities && pokemon.abilities.length == 1 ? pokemon.abilities[0] : "")),
-		"isAbilityActivated": "MassPokemon",
 		"item": set.item && typeof set.item !== "undefined" &&
 		(set.item === "Eviolite" || !(set.item.endsWith("ite") && set.item.endsWith("ite X") && set.item.endsWith("ite Y"))) ? set.item : "",
 		"status": "Healthy",
@@ -160,6 +159,9 @@ function MassPokemon(speciesName, setName) {
 			}));
 		}
 	}
+	// isAbilityActivated
+	// use the same default state as the user's Pokemon's checkbox
+	massPoke.isAbilityActivated = checkboxAbilities[massPoke.ability] ? checkboxAbilities[massPoke.ability].mass : false;
 
 	return massPoke;
 }

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -475,7 +475,16 @@ var checkboxAbilities = {
 	"Rivalry": { ap: false, mass: false },
 	"Flash Fire": { ap: false, mass: false },
 	"Plus": { ap: false, mass: false },
-	"Minus": { ap: false, mass: false }
+	"Minus": { ap: false, mass: false },
+	"Electromorphosis": { ap: false, mass: false },
+	"Wind Power": { ap: false, mass: false },
+	"Marvel Scale": { ap: false, mass: false },
+	"Guts": { ap: false, mass: false },
+	"Quick Feet": { ap: false, mass: false },
+	"Overgrow": { ap: false, mass: false },
+	"Blaze": { ap: false, mass: false },
+	"Torrent": { ap: false, mass: false },
+	"Swarm": { ap: false, mass: false }
 };
 
 // Based on input ability, show or hide the activated checkbox. Also use checkboxAbilities to initialize the checkbox state

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -887,7 +887,8 @@ $(".forme").change(function () {
 	var abilityList = altForme.abilities;
 	prependSpeciesAbilities(abilityList, container.parent().parent().prop("id"), container.find(".ability"));
 
-	if (setName !== "Blank Set" && pokemonName && abilities.includes(setdexAll[pokemonName][setName].ability)) {
+	if (pokemonName && setdexAll && setdexAll[pokemonName] && setdexAll[pokemonName][setName] &&
+		setName !== "Blank Set" && abilities.includes(setdexAll[pokemonName][setName].ability)) {
 		container.find(".ability").val(setdexAll[pokemonName][setName].ability);
 	} else if (abilityList && abilityList.length == 1) {
 		container.find(".ability").val(abilityList[0]);

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -718,10 +718,11 @@ $(".set-selector").bind("change", function () {
 	var abilityObj = pokeObj.find(".ability");
 	var abilityList = pokemon.abilities;
 	prependSpeciesAbilities(abilityList, pokeObjID, abilityObj);
-	// the following works as a way to change curAbilities[] without triggering ability.change()
-	// for the weather/terrain logic to work properly, leave those abilities in curAbilities[]
 	let pokeIndex = pokeObjID === "p1" ? 0 : 1;
-	if (!autoWeatherAbilities(curAbilities[pokeIndex]) && !autoTerrainAbilities(curAbilities[pokeIndex])) {
+	let oldAbility = curAbilities[pokeIndex];
+	// the following works as a way to change curAbilities[] without triggering ability.change()
+	// for the weather/terrain logic to work properly, leave those abilities in curAbilities[]. same goes for undoing old Intimidate
+	if (!autoWeatherAbilities(oldAbility) && !autoTerrainAbilities(oldAbility) && oldAbility !== "Intimidate") {
 		curAbilities[pokeIndex] = "";
 	}
 	if (pokemonName in setdexAll && setName in setdexAll[pokemonName]) {

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -877,12 +877,12 @@ $(".forme").change(function () {
 	var abilityList = altForme.abilities;
 	prependSpeciesAbilities(abilityList, container.parent().parent().prop("id"), container.find(".ability"));
 
-	if (abilityList && abilityList.length == 1) {
+	if (setName !== "Blank Set" && pokemonName && abilities.includes(setdexAll[pokemonName][setName].ability)) {
+		container.find(".ability").val(setdexAll[pokemonName][setName].ability);
+	} else if (abilityList && abilityList.length == 1) {
 		container.find(".ability").val(abilityList[0]);
 	} else if (abilities.includes(altForme.ab)) {
 		container.find(".ability").val(altForme.ab);
-	} else if (setName !== "Blank Set" && abilities.includes(setdexAll[pokemonName][setName].ability)) {
-		container.find(".ability").val(setdexAll[pokemonName][setName].ability);
 	} else {
 		container.find(".ability").val("");
 	}


### PR DESCRIPTION
- Electromorphosis, Wind Power, Marvel Scale, Guts, Quick Feet, Overgrow, Blaze, Torrent, and Swarm have been added as checkbox abilities.

Bug fixes:
- Pokemon with alternate formes will load their saved ability correctly.
- Activated Intimidate undoes its effect when the set changes.
- MassPokemon now only default an activatable ability to true if the checkbox will default to checked for a user's Pokemon in mass calc mode.