### PR TITLE
Seed update

### DIFF
--- a/_scripts/ap_calc.js
+++ b/_scripts/ap_calc.js
@@ -25,8 +25,7 @@ $("#p2 .ability").bind("change", function () {
 });
 
 $("#p2 .item").bind("keyup change", function () {
-	autosetStatus("#p2", $(this).val());
-	autoSetMultiHits($("#p2"));
+	itemChange($(this).val(), 2);
 });
 
 $("#p2 .status").bind("keyup change", function () {

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -105,6 +105,8 @@ function getDamageResult(attacker, defender, move, field) {
 	}
 
 	moveType = move.type;
+	attackerGrounded = isGrounded(attacker, field);
+	defenderGrounded = isGrounded(defender, field);
 
 	switch (move.name) {
 	case "Weather Ball":
@@ -222,8 +224,6 @@ function getDamageResult(attacker, defender, move, field) {
 		}
 	}
 
-	attackerGrounded = isGrounded(attacker, field);
-	defenderGrounded = isGrounded(defender, field);
 	moveCategory = move.category;
 	makesContact = move.makesContact;
 	if (isShellSideArmPhysical(attacker, defender, move)) {
@@ -508,7 +508,8 @@ function calcBP(attacker, defender, move, field, description, ateizeBoost) {
 		description.moveBP = basePower;
 		break;
 	case "Acrobatics":
-		basePower *= attacker.item === "Flying Gem" || attacker.item === "" ? 2 : 1;
+		let attackerEffectiveItem = getEffectiveItem(attacker, defender, field.terrain);
+		basePower *= attackerEffectiveItem === "Flying Gem" || attackerEffectiveItem === "" ? 2 : 1;
 		description.moveBP = basePower;
 		break;
 	case "Wake-Up Slap":
@@ -743,9 +744,9 @@ function calcBP(attacker, defender, move, field, description, ateizeBoost) {
 		description.weather = field.weather;
 	}
 
-	if (move.name === "Knock Off" && !(defender.item === "" ||
-		attacker.item === "Lustrous Globe" && attacker.name === "Palkia-O" ||
-		attacker.item === "Adamant Crystal" && attacker.name === "Dialga-O" ||
+	if (move.name === "Knock Off" && !(getEffectiveItem(defender, attacker, field.terrain) === "" ||
+		defender.item === "Lustrous Globe" && defender.name === "Palkia-O" ||
+		defender.item === "Adamant Crystal" && defender.name === "Dialga-O" ||
 		defender.item === "Griseous Orb" && (gen <= 8 || gen == 80) && defender.name === "Giratina-O" ||
 		defender.item === "Griseous Core" && defender.name === "Giratina-O" ||
 		defender.item.endsWith("Plate") && defender.name.startsWith("Arceus") ||
@@ -1375,6 +1376,15 @@ function isGrounded(pokemon, field) {
 		return true;
 	}
 	return !(pokemon.hasType("Flying") || pokemon.item === "Air Balloon" || pokemon.curAbility === "Levitate");
+}
+
+function getEffectiveItem(source, opponent, terrain) {
+	// Weak Pol
+	if (getSeedStat(source.item, terrain) ||
+		(source.item === "Adrenaline Orb" && opponent.curAbility === "Intimidate" && opponent.isAbilityActivated)) {
+		return "";
+	}
+	return source.item;
 }
 
 function hasPriority(move, attacker, field) {

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -69,6 +69,9 @@ $(".ability").bind("change", function () {
 	}
 });
 
+// empty calculate() so that shared_calc functions don't have to have a special exception in mass calc mode.
+function calculate() {}
+
 function MassPokemon(speciesName, setName) {
 	let pokemon = pokedex[speciesName];
 	let set = setdex[speciesName][setName];

--- a/honkalculate.html
+++ b/honkalculate.html
@@ -567,7 +567,8 @@ title: Battle Facilities Mass Calculator
                         <input class="btn-input calc-trigger" type="checkbox" id="foresightR" /><label class="btn btn-wide" for="foresightR">Foresight</label>
                     </div>
                 </div>-->
-                <div class="btn-group gen-specific g6 g7 g8 g80 g9">
+                <div class="btn-group hide">
+                <!--div class="btn-group gen-specific g6 g7 g8 g80 g9"-->
                     <div class="left" title="Has this Pokemon used Minimize?">
                         <input class="btn-input calc-trigger" type="checkbox" id="minimL" /><label class="btn btn-xwide" for="minimL">Minimize</label>
                     </div>

--- a/index.html
+++ b/index.html
@@ -577,7 +577,8 @@ title: Battle Facilities Calculator
 					<input class="btn-input calc-trigger" type="checkbox" id="foresightR" /><label class="btn btn-wide" for="foresightR">Foresight</label>
 				</div>
 			</div>-->
-			<div class="btn-group gen-specific g6 g7 g8 g80 g9">
+			<div class="btn-group hide">
+			<!--div class="btn-group gen-specific g6 g7 g8 g80 g9"-->
 				<div class="left" title="Has this Pokemon used Minimize?">
 					<input class="btn-input calc-trigger" type="checkbox" id="minimL" /><label class="btn btn-xwide" for="minimL">Minimize</label>
 				</div>


### PR DESCRIPTION
- Seed items activated in terrain now apply a visible stat stage.
- Activated Seed items and Adrenaline Orb no longer count as a held item for Acrobatics and Knock Off.
   - Poltergeist is the only other move that could have been influenced by this change. It does not currently have logic in the calc so nothing will be added for it at this time.
- The Minimize button will be indefinitely hidden/unusable. The power modifier it applied is not correct to every move in every gen and it applied a non-visible evasion mod.