### PR TITLE
Small upgrades

### DIFF
--- a/_scripts/damage_gen3.js
+++ b/_scripts/damage_gen3.js
@@ -3,8 +3,8 @@ function CALCULATE_ALL_MOVES_ADV(p1, p2, field) {
 	checkAirLock(p2, field);
 	checkForecast(p1, field.getWeather());
 	checkForecast(p2, field.getWeather());
-	p1.stats[SP] = getFinalSpeed(p1, field.getWeather(), field.getTerrain());
-	p2.stats[SP] = getFinalSpeed(p2, field.getWeather(), field.getTerrain());
+	p1.stats[SP] = getFinalSpeed(p1, p2, field);
+	p2.stats[SP] = getFinalSpeed(p2, p1, field);
 	var side1 = field.getSide(1);
 	var side2 = field.getSide(0);
 	var results = [[], []];
@@ -22,8 +22,8 @@ function CALCULATE_MOVES_OF_ATTACKER_ADV(attacker, defender, field) {
 	checkIntimidate(defender, attacker);
 	checkForecast(attacker, field.getWeather());
 	checkForecast(defender, field.getWeather());
-	attacker.stats[SP] = getFinalSpeed(attacker, field.getWeather());
-	defender.stats[SP] = getFinalSpeed(defender, field.getWeather());
+	attacker.stats[SP] = getFinalSpeed(attacker, defender, field);
+	defender.stats[SP] = getFinalSpeed(defender, attacker, field);
 	var defenderSide = field.getSide(~~(mode === "one-vs-all"));
 	var results = [];
 	for (var i = 0; i < 4; i++) {

--- a/_scripts/damage_gen4.js
+++ b/_scripts/damage_gen4.js
@@ -5,8 +5,8 @@ function CALCULATE_ALL_MOVES_PTHGSS(p1, p2, field) {
 	checkForecast(p2, field.getWeather());
 	checkKlutz(p1);
 	checkKlutz(p2);
-	p1.stats[SP] = getFinalSpeed(p1, field.getWeather());
-	p2.stats[SP] = getFinalSpeed(p2, field.getWeather());
+	p1.stats[SP] = getFinalSpeed(p1, p2, field);
+	p2.stats[SP] = getFinalSpeed(p2, p1, field);
 	var side1 = field.getSide(1);
 	var side2 = field.getSide(0);
 	var results = [[], []];
@@ -28,8 +28,8 @@ function CALCULATE_MOVES_OF_ATTACKER_PTHGSS(attacker, defender, field) {
 	checkIntimidate(defender, attacker);
 	checkKlutz(attacker);
 	checkKlutz(defender);
-	attacker.stats[SP] = getFinalSpeed(attacker, field.getWeather());
-	defender.stats[SP] = getFinalSpeed(defender, field.getWeather());
+	attacker.stats[SP] = getFinalSpeed(attacker, defender, field);
+	defender.stats[SP] = getFinalSpeed(defender, attacker, field);
 	checkDownload(attacker, defender);
 	var defenderSide = field.getSide(~~(mode === "one-vs-all"));
 	var results = [];

--- a/_scripts/damage_gen4.js
+++ b/_scripts/damage_gen4.js
@@ -204,6 +204,7 @@ function getDamageResultPtHGSS(attacker, defender, move, field) {
 		description.moveBP = basePower;
 		break;
 	case "Wring Out":
+	case "Crush Grip":
 		basePower = Math.floor(defender.curHP * 120 / defender.maxHP) + 1;
 		description.moveBP = basePower;
 		break;
@@ -302,6 +303,9 @@ function getDamageResultPtHGSS(attacker, defender, move, field) {
 		description.attackerAbility = attacker.ability;
 	} else if (!isPhysical && (attacker.ability === "Plus" || attacker.ability === "Minus") && attacker.isAbilityActivated) {
 		attack = Math.floor(attack * 1.5);
+		description.attackerAbility = attacker.ability;
+	} else if (isPhysical && attacker.ability === "Slow Start" && attacker.isAbilityActivated) {
+		attack = Math.floor(attack * 0.5);
 		description.attackerAbility = attacker.ability;
 	}
 

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -842,8 +842,8 @@ function calcAtk(attacker, defender, move, field, description) {
 	}
 
 	var atMods = [];
-	if (attacker.curAbility === "Defeatist" && attacker.curHP <= attacker.maxHP / 2 ||
-		attacker.curAbility === "Slow Start" && moveCategory === "Physical") {
+	if (attacker.curAbility === "Defeatist" && (attacker.curHP <= attacker.maxHP / 2 || attacker.isAbilityActivated) ||
+		attacker.curAbility === "Slow Start" && moveCategory === "Physical" && attacker.isAbilityActivated) {
 		atMods.push(0x800);
 		description.attackerAbility = attacker.curAbility;
 	}
@@ -1366,6 +1366,8 @@ function getFinalSpeed(pokemon, weather, terrain) {
 	} else if (checkProtoQuarkHighest(pokemon, weather, terrain) === SP ||
 		pokemon.curAbility === "Quick Feet" && (pokemon.status !== "Healthy" || pokemon.isAbilityActivated)) {
 		speed = Math.floor(speed * 1.5);
+	} else if (pokemon.curAbility === "Slow Start" && pokemon.isAbilityActivated) {
+		speed = Math.floor(speed * 0.5);
 	}
 	return speed;
 }

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -1477,12 +1477,12 @@ function checkSeedsHonk(pokemon, terrain) {
 }
 
 function isShellSideArmPhysical(attacker, defender, move) {
-	if (move.name != "Shell Side Arm") {
+	if (move.name !== "Shell Side Arm") {
 		return false;
 	}
-	let scaler = Math.floor(2 * attacker.level / 5) + 2;
-	let phys = Math.floor(scaler * move.basePower * attacker.stats[AT] / defender.stats[DF]);
-	let spec = Math.floor(scaler * move.basePower * attacker.stats[SA] / defender.stats[SD]);
+	let scaler = (Math.floor(2 * attacker.level / 5) + 2) * move.bp;
+	let phys = Math.floor(scaler * attacker.stats[AT] / defender.stats[DF]);
+	let spec = Math.floor(scaler * attacker.stats[SA] / defender.stats[SD]);
 	return phys > spec;
 }
 

--- a/_scripts/game_data/item_data.js
+++ b/_scripts/game_data/item_data.js
@@ -70,6 +70,25 @@ ITEMS_ADV.splice(ITEMS_ADV.indexOf("Gold Berry"), 1);
 ITEMS_ADV.splice(ITEMS_ADV.indexOf("Pink Bow"), 1);
 ITEMS_ADV.splice(ITEMS_ADV.indexOf("Polkadot Bow"), 1);
 
+var PLATES = [
+	"Fist Plate",
+	"Sky Plate",
+	"Toxic Plate",
+	"Earth Plate",
+	"Stone Plate",
+	"Insect Plate",
+	"Spooky Plate",
+	"Iron Plate",
+	"Flame Plate",
+	"Splash Plate",
+	"Meadow Plate",
+	"Zap Plate",
+	"Mind Plate",
+	"Icicle Plate",
+	"Draco Plate",
+	"Dread Plate"
+];
+
 var ITEMS_DPP = ITEMS_ADV.concat([
 	"Adamant Orb",
 	"Babiri Berry",
@@ -85,24 +104,16 @@ var ITEMS_DPP = ITEMS_ADV.concat([
 	"Colbur Berry",
 	"Custap Berry",
 	"Damp Rock",
-	"Draco Plate",
-	"Dread Plate",
 	"Durin Berry",
-	"Earth Plate",
 	"Expert Belt",
-	"Fist Plate",
 	"Flame Orb",
-	"Flame Plate",
 	"Focus Sash",
 	"Grip Claw",
 	"Griseous Orb",
 	"Haban Berry",
 	"Heat Rock",
-	"Icicle Plate",
 	"Icy Rock",
-	"Insect Plate",
 	"Iron Ball",
-	"Iron Plate",
 	"Jaboca Berry",
 	"Kasib Berry",
 	"Kebia Berry",
@@ -110,10 +121,8 @@ var ITEMS_DPP = ITEMS_ADV.concat([
 	"Life Orb",
 	"Light Clay",
 	"Lustrous Orb",
-	"Meadow Plate",
 	"Metronome",
 	"Micle Berry",
-	"Mind Plate",
 	"Muscle Band",
 	"Occa Berry",
 	"Odd Incense",
@@ -127,24 +136,19 @@ var ITEMS_DPP = ITEMS_ADV.concat([
 	"Rowap Berry",
 	"Shed Shell",
 	"Shuca Berry",
-	"Sky Plate",
 	"Smooth Rock",
-	"Splash Plate",
-	"Spooky Plate",
 	"Sticky Barb",
-	"Stone Plate",
 	"Tanga Berry",
 	"Toxic Orb",
-	"Toxic Plate",
 	"Wacan Berry",
 	"Watmel Berry",
 	"Wave Incense",
 	"Wide Lens",
 	"Wise Glasses",
 	"Yache Berry",
-	"Zap Plate",
 	"Zoom Lens"
-]);
+],
+PLATES);
 
 var ITEMS_BW = ITEMS_DPP.concat([
 	"Absorb Bulb",
@@ -170,13 +174,13 @@ var ITEMS_XY = ITEMS_BW.concat([
 	"Kee Berry",
 	"Luminous Moss",
 	"Maranga Berry",
-	"Pixie Plate",
 	"Power Herb",
 	"Roseli Berry",
 	"Safety Goggles",
 	"Snowball",
 	"Weakness Policy"
 ]);
+[ITEMS_XY, PLATES].forEach(itemSet => { itemSet.push("Pixie Plate"); });
 
 ITEMS_XY.splice(ITEMS_XY.indexOf("BlackGlasses"), 1, "Black Glasses");
 ITEMS_XY.splice(ITEMS_XY.indexOf("DeepSeaScale"), 1, "Deep Sea Scale");
@@ -288,6 +292,13 @@ var Z_CRYSTALS = [
 ITEMS_BW = ITEMS_BW.concat(NON_NORMAL_GEMS);
 
 ITEMS_SM = ITEMS_SM.concat(Z_CRYSTALS);
+
+// Remove Plates from an item array.
+for (let itemSet of [ITEMS_SS]) {
+	for (let plate of PLATES) {
+		itemSet.splice(itemSet.indexOf(plate), 1);
+	}
+}
 
 function getTechnoBlast(item) {
 	switch (item) {

--- a/_scripts/game_data/setdex_gen4_sets.js
+++ b/_scripts/game_data/setdex_gen4_sets.js
@@ -11912,7 +11912,7 @@ SETDEX_PHGSS = {
       "item": "Kasib Berry",
       "tier": "50"
     },
-    "Mismagius-2 ( )": {
+    "Mismagius-2 (549)": {
       "evs": {
         "sa": 252,
         "sd": 252

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -500,6 +500,8 @@ function getFinalSpeedHonk() {
 		speed *= 2;
 	} else if (ability === "Quick Feet" && ($(".status").val() !== "Healthy" || $(".isActivated").prop("checked"))) {
 		speed = Math.floor(speed * 1.5);
+	} else if (ability === "Slow Start" && $(".isActivated").prop("checked")) {
+		speed = Math.floor(speed * 0.5);
 	}
 	$(".totalMod").text(speed);
 }

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -532,7 +532,8 @@ var checkboxAbilities = {
 	"Torrent": { ap: false, mass: false },
 	"Swarm": { ap: false, mass: false },
 	"Slow Start": { ap: true, mass: true },
-	"Defeatist": { ap: false, mass: false }
+	"Defeatist": { ap: false, mass: false },
+	"Unburden": { ap: false, mass: false }
 };
 
 // Based on input ability, show or hide the activated checkbox. Also use checkboxAbilities to initialize the checkbox state

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -513,7 +513,7 @@ function autoSetSteely(ability, side) {
 	$("input:checkbox[id='steelySpirit" + side + "']").prop("checked", (!isNeutralizingGas && ability === "Steely Spirit"));
 }
 
-// each ability can independantly initialize as checked or unchecked in each calc mode
+// each ability can independently initialize as checked or unchecked in each calc mode
 var checkboxAbilities = {
 	"Analytic": { ap: true, mass: true },
 	"Intimidate": { ap: false, mass: true },
@@ -530,7 +530,9 @@ var checkboxAbilities = {
 	"Overgrow": { ap: false, mass: false },
 	"Blaze": { ap: false, mass: false },
 	"Torrent": { ap: false, mass: false },
-	"Swarm": { ap: false, mass: false }
+	"Swarm": { ap: false, mass: false },
+	"Slow Start": { ap: true, mass: true },
+	"Defeatist": { ap: false, mass: false }
 };
 
 // Based on input ability, show or hide the activated checkbox. Also use checkboxAbilities to initialize the checkbox state


### PR DESCRIPTION
- Checkboxes have been added for Slow Start, Defeatist, and Unburden.
   - Slow Start and Crush Grip have been implemented in gen 4.
   - Unburden has functionality now, including detection of when it should activate even while unchecked (i.e. a seed has been consumed by terrain).
- Shell Side Arm has been fixed.
- SwSh has had the Plate items removed from its item pool. This also sets up things for future gens to easily remove plates.