### PR TITLE
Mass calc improvements

### DIFF
--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -391,7 +391,7 @@ function constructDataTable() {
 		rowCallback: function(row, data, index) {
 			let userSpeed = parseInt($(".totalMod").text());
 			let massSpeed = data["speed"];
-			if (parseInt($(".sp .iv").text()) <= 5) {
+			if (parseInt($(".sp .ivs").val()) <= 7) {
 				if (massSpeed > userSpeed) {
 					return;
 				}

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -507,44 +507,11 @@ function getBottomOffset(obj) {
 }
 
 $(".isActivated").bind("change", function () {
-	getFinalSpeedHonk();
+	setDisplayedSpeed();
 });
 
-function getFinalSpeedHonk() {
-	var speed = getModifiedStat($(".sp .total").text(), $(".sp .boost").val());
-	var item = $(".item").val();
-	var ability = $(".ability").val();
-	var weather = $("input[name=weather]:checked").attr('value');
-	var terrain = $("input[name=terrain]:checked").attr('value');
-	if ((ability === "Protosynthesis" && (item === "Booster Energy" || weather.indexOf("Sun") > -1)) ||
-		(ability === "Quark Drive" && (item === "Booster Energy" || terrain === "Electric"))) {
-		if (speed > getModifiedStat($(".at .total").text(), $(".at .boost").val()) && speed > getModifiedStat($(".df .total").text(), $(".df .boost").val()) &&
-			speed > getModifiedStat($(".sa .total").text(), $(".sa .boost").val()) && speed > getModifiedStat($(".sd .total").text(), $(".sd .boost").val())) {
-			speed = Math.floor(speed * 1.5);
-		}
-	}
-	if (item === "Choice Scarf") {
-		speed = Math.floor(speed * 1.5);
-	} else if (item === "Macho Brace" || item === "Iron Ball") {
-		speed = Math.floor(speed / 2);
-	}
-
-	if ($(".status").val() === "Paralyzed" && ability !== "Quick Feet") {
-		speed = Math.floor(speed / (gen <= 6 ? 4 : 2));
-	}
-
-	if (ability === "Chlorophyll" && weather.indexOf("Sun") > -1 && item !== "Utility Umbrella" ||
-		ability === "Sand Rush" && weather === "Sand" ||
-		ability === "Swift Swim" && weather.indexOf("Rain") > -1 && item !== "Utility Umbrella" ||
-		ability === "Slush Rush" && (weather.indexOf("Hail") > -1 || weather === "Snow") ||
-		ability === "Surge Surfer" && terrain === "Electric") {
-		speed *= 2;
-	} else if (ability === "Quick Feet" && ($(".status").val() !== "Healthy" || $(".isActivated").prop("checked"))) {
-		speed = Math.floor(speed * 1.5);
-	} else if (ability === "Slow Start" && $(".isActivated").prop("checked")) {
-		speed = Math.floor(speed * 0.5);
-	}
-	$(".totalMod").text(speed);
+function setDisplayedSpeed() {
+	$(".totalMod").text(getFinalSpeed(new Pokemon($("#p1")), {}, new Field()));
 }
 
 var dtHeight, dtWidth;
@@ -571,6 +538,6 @@ $(document).ready(function () {
 	constructDataTable();
 	placeBsBtn();
 
-	$(".calc-trigger").bind("change keyup", getFinalSpeedHonk);
-	getFinalSpeedHonk();
+	$(".calc-trigger").bind("change keyup", setDisplayedSpeed);
+	setDisplayedSpeed();
 });

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -223,7 +223,7 @@ function performCalculations() {
 			let maxDamage;
 			let highestDamage = 0;
 			let highestN = 0;
-			let data = { setName: setName, move: "(No Move)", percentRange: "0 - 0%", koChance: "nice move" };
+			let data = { setName: setName, move: "(No Move)", percentRange: "0 - 0%", koChance: "nice move", speed: setPoke.stats[SP] };
 			if (mode === "one-vs-all") {
 				data.type1 = defender.type1;
 				data.type2 = defender.type2 ? defender.type2 : "";
@@ -353,8 +353,12 @@ function constructDataTable() {
 		destroy: true,
 		columnDefs: [
 			{ // Sort KO Chance by damage% instead
-				"orderData": [2], // percentRange = col 2
-				"targets": 3 // koChance = col 3
+				orderData: [2], // percentRange = col 2
+				targets: 3 // koChance = col 3
+			},
+			{
+				width: "0", // this makes the column as small as possible
+				targets: 4 // speed = col 4
 			}
 		],
 		columns: [
@@ -362,9 +366,28 @@ function constructDataTable() {
 			{ data: "move" },
 			{ data: 'percentRange', type: "damage100" }, // type specifies that this column is sorted via the damage100 functions
 			{ data: 'koChance' },
+			{ data: 'speed' },
 			{ data: 'type1', visible: false, searchable: false },
 			{ data: 'type2', visible: false, searchable: false }
 		],
+		rowCallback: function(row, data, index) {
+			let userSpeed = parseInt($(".totalMod").text());
+			let massSpeed = data["speed"];
+			if (parseInt($(".sp .iv").text()) <= 5) {
+				if (massSpeed > userSpeed) {
+					return;
+				}
+			} else {
+				if (massSpeed < userSpeed) {
+					return;
+				}
+			}
+			// speed is col 4
+			$(row).find("td:eq(4)").css({
+				"color": massSpeed === userSpeed ? "gold" : "#F02020",
+				"font-weight": "bold"
+			});
+		},
 		dom: 'frti',
 		/*colVis: { The options that allows selection of which columns to include in the table
 			exclude: (gen > 2) ? [0, 1, 2] : (gen === 2) ? [0, 1, 2, 7] : [0, 1, 2, 7, 8],

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -724,19 +724,26 @@ function autoSetRuin(ability, side) {
 }
 
 function autoSetMultiHits(pokeInfo) {
-	var ability = pokeInfo.find(".ability").val();
-	var item = pokeInfo.find(".item").val();
-	for (var i = 1; i <= 4; i++) {
-		var moveInfo = pokeInfo.find(".move" + i);
-		var moveName = moveInfo.find("select.move-selector").val();
-		if (moveName === "Population Bomb") {
-			moveInfo.children(".move-hits").val(10);
-		} else if (moveName === "Triple Axel") {
-			moveInfo.children(".move-hits").val(3);
-		} else {
-			moveInfo.children(".move-hits").val(ability === "Skill Link" ? 5 : (item === "Loaded Dice" ? 4 : 3));
-		}
+	let ability = pokeInfo.find(".ability").val();
+	let item = pokeInfo.find(".item").val();
+	for (let i = 1; i <= 4; i++) {
+		let moveInfo = pokeInfo.find(".move" + i);
+		let moveName = moveInfo.find("select.move-selector").val();
+		moveInfo.children(".move-hits").val(getDefaultMultiHits(moveName, ability, item));
 	}
+}
+
+function getDefaultMultiHits(moveName, ability, item) {
+	let move = moves[moveName];
+	if (!move || !move.maxMultiHits) {
+		return 1;
+	}
+	if (ability === "Skill Link" || moveName === "Population Bomb" || moveName === "Triple Axel") {
+		return move.maxMultiHits;
+	} else if (item === "Loaded Dice") {
+		return 4;
+	}
+	return 3;
 }
 
 $(".status").bind("keyup change", function () {
@@ -766,7 +773,7 @@ $(".move-selector").change(function () {
 			moveHits.append($("<option></option>").attr("value", i).text(i + " hits"));
 		}
 		moveHits.show();
-		moveHits.val(ability === "Skill Link" || moveName === "Population Bomb" ? maxMultiHits : (pokeInfo.find(".item").val() === "Loaded Dice" ? 4 : 3));
+		moveHits.val(getDefaultMultiHits(moveName, ability, pokeInfo.find(".item").val()));
 	} else {
 		moveHits.hide();
 	}

--- a/honkalculate.html
+++ b/honkalculate.html
@@ -699,8 +699,9 @@ title: Battle Facilities Mass Calculator
                         <th>Best Move</th><!-- 1 -->
                         <th>Damage (%)</th><!-- 2 -->
                         <th>KO Chance</th><!-- 3 -->
-                        <th>Type 1</th><!-- 4 -->
-                        <th>Type 2</th><!-- 5 -->
+                        <th>Speed</th><!-- 4 -->
+                        <th>Type 1</th><!-- 5 -->
+                        <th>Type 2</th><!-- 6 -->
                     </tr>
                 </thead>
             </table>


### PR DESCRIPTION
- Speed is now a column in the mass calc output table, highlighting opponents that outspeed the user in red and ties in yellow.
   - A user's Pokemon with a low speed IV will instead highlight for underspeeding opponents.
- Seismic Toss is now accurately calculating for best move in the mass calc. It will be better selected as the best move in some scenarios, but this selection is still likely not perfectly ideal.
- Captured a fix from EisenTree's calc where the calc can error when loading a set with Triple Axel.