### PR TITLE
Refine first hit system

### DIFF
--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -1404,7 +1404,7 @@ function getEffectiveItem(source, opponent, terrain) {
 
 function hasPriority(move, attacker, field) {
 	return move.hasPriority ||
-		(attacker.curAbility === "Gale Wings" && moveType === "Flying") ||
+		(attacker.curAbility === "Gale Wings" && moveType === "Flying" && move.name !== "Tera Blast") ||
 		(attacker.curAbility === "Triage" && move.percentHealed) ||
 		(move.name === "Grassy Glide" && field.terrain === "Grassy" && attackerGrounded);
 }

--- a/_scripts/export.js
+++ b/_scripts/export.js
@@ -73,7 +73,17 @@ function exportToPsFormat(pokeInfo) {
 		var speciesName = name;
 	}
 
-	finalText = speciesName + (pokemon.item ? " @ " + pokemon.item : "") + "\n";
+	// convert items that have old names in old gens
+	let item = pokemon.item;
+	if (gen < 6 && item) {
+		for (let [oldName, newName] of Object.entries(oldItemNames)) {
+			if (item === newName) {
+				item = oldName;
+				break;
+			}
+		}
+	}
+	finalText = speciesName + (item ? " @ " + item : "") + "\n";
 	finalText += pokemon.ability ? "Ability: " + pokemon.ability + "\n" : "";
 	finalText += pokemon.level !== 50 || gen == 3 || gen == 4 ? "Level: " + pokemon.level + "\n" : "";
 	finalText += pokemon.teraType ? "Tera Type: " + pokemon.teraType + "\n" : "";


### PR DESCRIPTION
- Cleaned up the first hit code. The new approach to first hit recalculation is both easier to understand and removed complicated conditionals.
   - This change isn't meant to affect anything the user sees since it was a code rework. However, this should have fixed some interactions between things that use the first hit system.
- Added Knock Off to the first hit system.

Previous undocumented changes:
- Instances of items that had their names changed in gen 6 (e.g. "BlackGlasses" -> "Black Glasses") were replaced with their new names across the calc. The old names are still used for set import and export, for purposes of interfacing with other applications that use Showdown format.