### PR TITLE
Use nickname as spreadName

### DIFF
--- a/_scripts/import_custom.js
+++ b/_scripts/import_custom.js
@@ -151,6 +151,7 @@ var savecustom = function () {
 			firstParenth = lines[0].lastIndexOf("(");
 			lastParenth = lines[0].lastIndexOf(")");
 			species = lines[0].substring(firstParenth + 1, lastParenth).trim();
+			spreadName = lines[0].substring(0, firstParenth-1).trim();
 		} else {
 			species = lines[0].split("@")[0].trim(); //species is always first
 		}


### PR DESCRIPTION
Proposing to use the showdown nickname, as the spreadName, this makes importing groups of the same mon easier (i.e. 17 for hall).

I am concerned about usability where there is a nickname the user does not want, checking if the entry box is not the default text could be an option but is not flawless. 