### PR TITLE
Correct status orbs end-of-turn damage

### DIFF
--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -1210,27 +1210,28 @@ function getDescriptionPokemonName(pokemon) {
 	// if the setName ends with something in parens, remove the parens
 	let regexMatch = endsInParensRegex.exec(pokemon.setName);
 	let displaySetName = regexMatch ? pokemon.setName.substring(0, regexMatch.index) : pokemon.setName;
+	let setSuffix = displaySetName.substring(displaySetName.lastIndexOf("-"));
+	if (setSuffix.includes(",")) {
+		// BDSP has some sets of the form `speciesName-1,2,3`. Remove all set numbers except the first one.
+		setSuffix = setSuffix.substring(setSuffix.indexOf(","));
+		displaySetName = displaySetName.substring(0, displaySetName.length - setSuffix.length);
+	}
+	if (setSuffix.length > MAX_SET_SUFFIX_LENGTH) {
+		return pokemon.name;
+	}
 	if (pokemon.name in setdex && pokemon.setName in setdex[pokemon.name]) {
-		// the name and setName are straightforward. the setName isn't much longer than the name. setName can simply be returned.
-		if (displaySetName.length > pokemon.name.length + MAX_SET_SUFFIX_LENGTH) {
-			return pokemon.name;
-		}
+		// the name and setName are straightforward. the set name can simply be returned.
 		return displaySetName;
 	}
 	let nameDexEntry = pokedex[pokemon.name];
 	if (nameDexEntry && nameDexEntry.hasBaseForme && nameDexEntry.hasBaseForme in setdex && pokemon.setName in setdex[nameDexEntry.hasBaseForme]) {
 		// the pokemon is some forme. take the set suffix and put it at the end of the forme.
-		let setSuffix = displaySetName.substring(displaySetName.lastIndexOf("-"));
-		if (setSuffix.length > MAX_SET_SUFFIX_LENGTH) {
-			return pokemon.name;
-		}
 		return pokemon.name + setSuffix;
 	}
 	// don't print Gmax in the description
 	return pokemon.name.endsWith("-Gmax") ? pokemon.name.substring(0, pokemon.name.lastIndexOf("-Gmax")) : pokemon.name;
 }
 
-const VERSUS = "vs. ";
 function buildDescription(description) {
 	var output = "";
 	if (description.attackBoost) {
@@ -1285,7 +1286,7 @@ function buildDescription(description) {
 	if (description.isSpread) {
 		output += "(spread) ";
 	}
-	output += VERSUS;
+	output += "vs. ";
 	if (description.defenseBoost) {
 		if (description.defenseBoost > 0) {
 			output += "+";

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -579,22 +579,10 @@ function calcBP(attacker, defender, move, field, description, ateizeBoost) {
 
 	if (attacker.curAbility === "Supreme Overlord" && field.faintedCount > 0) {
 		// modifies the base power https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9421520
-		let multiplier;
-		switch (field.faintedCount) {
-			case 1:
-				multiplier = 1.1;
-				break;
-			case 2:
-				multiplier = 1.2;
-				break;
-			case 3:
-				multiplier = 1.3;
-				break;
-			case 4:
-				multiplier = 1.4;
-				break;
-			default:
-				multiplier = 1.5;
+		let multiplierValues = [1.1, 1.2, 1.3, 1.4];
+		let multiplier = multiplierValues[field.faintedCount - 1];
+		if (!multiplier) {
+			multiplier = 1.5;
 		}
 		bpMods.push(Math.ceil(0x1000 * multiplier));
 		description.attackerAbility = attacker.curAbility + " (" + multiplier + "x BP)";

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -749,9 +749,10 @@ function getDefaultMultiHits(moveName, ability, item) {
 
 $(".status").bind("keyup change", function () {
 	if ($(this).val() === "Badly Poisoned") {
-		$(this).parent().children(".toxic-counter").show();
+		$(this).siblings(".toxic-counter").show();
+		$(this).siblings(".toxic-counter").val($(this).parent().siblings().find(".item").val() === "Toxic Orb" ? 0 : 1);
 	} else {
-		$(this).parent().children(".toxic-counter").hide();
+		$(this).siblings(".toxic-counter").hide();
 	}
 });
 

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -999,8 +999,8 @@ $(".forme").change(function () {
 	var altForme = pokedex[$(this).val()],
 		container = $(this).closest(".info-group").siblings(),
 		fullSetName = container.find(".select2-chosen").first().text(),
-		pokemonName = fullSetName.substring(0, fullSetName.indexOf(" (")),
-		setName = fullSetName.substring(fullSetName.indexOf("(") + 1, fullSetName.lastIndexOf(")"));
+		pokemonName = fullSetName.substring(0, fullSetName.indexOf(" ("));
+	let setName = fullSetName.substring(fullSetName.indexOf("(") + 1, fullSetName.lastIndexOf(")"));
 
 	if (gen != 9 || !$(this).closest(".poke-info").find(".tera").prop("checked")) {
 		$(this).parent().siblings().find(".type1").val(altForme.t1);
@@ -1915,12 +1915,12 @@ function getSetOptions() {
 			"text": pokeName
 		});
 		if (pokeName in setdex) {
-			for (setName in setdex[pokeName]) {
+			for (const setName in setdex[pokeName]) {
 				setOptions.push(setOptionsObject(pokeName, setName));
 			}
 		}
 		if (pokeName in SETDEX_CUSTOM) {
-			for (setName in SETDEX_CUSTOM[pokeName]) {
+			for (const setName in SETDEX_CUSTOM[pokeName]) {
 				setOption = setOptionsObject(pokeName, setName);
 				setOption.set = setOption.text; // the selectable text matches the display text
 				customSetOptions.push(setOption);

--- a/honkalculate.html
+++ b/honkalculate.html
@@ -322,6 +322,7 @@ title: Battle Facilities Mass Calculator
                             <option value="Confused">Confused</option>
                         </select>
                         <select class="toxic-counter calc-trigger hide">
+                            <option value="0">0/16</option>
                             <option value="1">1/16</option>
                             <option value="2">2/16</option>
                             <option value="3">3/16</option>

--- a/index.html
+++ b/index.html
@@ -326,6 +326,7 @@ title: Battle Facilities Calculator
 						<option value="Confused">Confused</option>
 					</select>
 					<select class="toxic-counter calc-trigger hide">
+						<option value="0">0/16</option>
 						<option value="1">1/16</option>
 						<option value="2">2/16</option>
 						<option value="3">3/16</option>
@@ -984,6 +985,7 @@ title: Battle Facilities Calculator
 						<option value="Confused">Confused</option>
 					</select>
 					<select class="toxic-counter calc-trigger hide">
+						<option value="0">0/16</option>
 						<option value="1">1/16</option>
 						<option value="2">2/16</option>
 						<option value="3">3/16</option>


### PR DESCRIPTION
- A Flame Orb holder will count one fewer turn of burn for KO chance. A Toxic Orb holder will start its toxic counter at 0 instead of 1.
   - As part of this adjustment, issues with the toxic counter were found and corrected.

Previously undocumented:
- The BDSP sets have been regenerated to be more in line with other lookups and game data.
   - Duplicate sets are fully included, which has an impact in the numbering of some species. Duplicate sets have been combined into one set entry however (e.g. Gyarados-3,4).