### PR TITLE
Mass calc Allv1 treats any OHKO chance for OHKO counter

### DIFF
--- a/_scripts/ap_calc.js
+++ b/_scripts/ap_calc.js
@@ -92,16 +92,15 @@ for (var i = 0; i < 4; i++) {
 
 var damageResults;
 function calculate() {
-	var p1info = $("#p1");
-	var p2info = $("#p2");
-	var p1 = new Pokemon(p1info);
-	var p2 = new Pokemon(p2info);
-	var field = new Field();
+	let p1info = $("#p1");
+	let p2info = $("#p2");
+	let p1 = new Pokemon(p1info);
+	let p2 = new Pokemon(p2info);
+	let field = new Field();
 	//optimizeEVs("#p1", p1);
 	//optimizeEVs("#p2", p2);
 	damageResults = calculateAllMoves(p1, p2, field);
-	p1info.find(".sp .totalMod").text(p1.stats.sp);
-	p2info.find(".sp .totalMod").text(p2.stats.sp);
+	setSpeed(p1info, p2info, p1, p2);
 	// Removed the auto-select highest damage since it's rarely useful for facilities (or any format?)
 	//var highestMaxPercent = -1;
 	//var bestResult = $(resultLocations[0][0].move);
@@ -125,6 +124,13 @@ function calculate() {
 $(".result-move").change(function () {
 	updateDamageText($(this));
 });
+
+function setSpeed(p1info, p2info, p1, p2) {
+	let p1Speed = p1.stats.sp;
+	let p2Speed = p2.stats.sp;
+	p1info.find(".sp .totalMod").text(p1Speed).css({ "font-weight": p1Speed > p2Speed ? "bold" : "" });
+	p2info.find(".sp .totalMod").text(p2Speed).css({ "font-weight": p2Speed > p1Speed ? "bold" : "" });
+}
 
 const MAX_GROUP_COUNT = 14;
 const MAX_UNGROUPED_COUNT = MAX_GROUP_COUNT + 4;

--- a/_scripts/damage_modern.js
+++ b/_scripts/damage_modern.js
@@ -1398,12 +1398,12 @@ function getMoveEffectiveness(move, mType, defType, isGhostRevealed, field, isSt
 	} else if (mType === "None" || mType === "Stellar") {
 		// let the caller handle Stellar attacking a terastallized defender
 		return 1;
-	} else if (isGhostRevealed && defType === "Ghost" && (mType === "Normal" || mType === "Fighting")) {
+	} else if (isGhostRevealed && defType === "Ghost" && ["Normal", "Fighting"].some(type => type == mType)) {
 		return 1;
 	} else if (defType === "Flying" && mType === "Ground" && (defenderGrounded || move.name === "Thousand Arrows")) {
 		// let the caller handle the Iron Ball and Thousand Arrows cases
 		return 1;
-	} else if (isStrongWinds && defType === "Flying" && (mType === "Electric" || mType === "Ice" || mType === "Rock")) {
+	} else if (isStrongWinds && defType === "Flying" && ["Electric", "Ice", "Rock"].some(type => type == mType)) {
 		description.weather = "Strong Winds";
 		return 1;
 	} else if (move.name === "Freeze-Dry" && defType === "Water") {
@@ -1501,11 +1501,11 @@ function killsShedinja(attacker, defender, move, field = {}) {
 		return false;
 	}
 	let afflictable = defender.status === "Healthy" && !(field.terrain === "Misty" && isGrounded(defender, field));
-	let poisonable = afflictable && !defender.hasType("Poison") && !defender.hasType("Steel");
+	let poisonable = afflictable && !["Poison", "Steel"].some(type => defender.hasType(type));
 	let burnable = afflictable && !defender.hasType("Fire");
 
 	let weather = defender.item !== "Safety Goggles" &&
-	((move.name === "Sandstorm" && !defender.hasType("Rock") && !defender.hasType("Steel") && !defender.hasType("Ground")) || (move.name === "Hail" && !defender.hasType("Ice")));
+	((move.name === "Sandstorm" && !["Rock", "Steel", "Ground"].some(type => defender.hasType(type))) || (move.name === "Hail" && !defender.hasType("Ice")));
 	// akin to Sash, status berries should not be accounted for
 	let poison = (["Toxic", "Poison Gas", "Toxic Thread"].includes(move.name) || (move.name === "Poison Powder" && defender.item !== "Safety Goggles" && !defender.hasType("Grass"))) &&
 	(poisonable || (afflictable && attacker.curAbility === "Corrosion"));

--- a/_scripts/game_data/move_data.js
+++ b/_scripts/game_data/move_data.js
@@ -403,6 +403,13 @@ var MOVES_RBY = {
 		"makesContact": true,
 		"acc": 75
 	},
+	"Mega Punch": {
+		"bp": 80,
+		"type": "Normal",
+		"category": "Physical",
+		"makesContact": true,
+		"acc": 85
+	},
 	"Mimic": {
 		"bp": 0,
 		"type": "Normal"
@@ -480,7 +487,6 @@ var MOVES_RBY = {
 		"bp": 55,
 		"type": "Grass",
 		"category": "Physical",
-		"alwaysCrit": true,
 		"isSlicing": true,
 		"acc": 95
 	},
@@ -518,6 +524,14 @@ var MOVES_RBY = {
 		"type": "Rock",
 		"category": "Physical",
 		"acc": 90
+	},
+	"Rolling Kick": {
+		"bp": 60,
+		"type": "Fighting",
+		"category": "Physical",
+		"makesContact": true,
+		"hasSecondaryEffect": true,
+		"acc": 85
 	},
 	"Screech": {
 		"bp": 0,
@@ -559,11 +573,17 @@ var MOVES_RBY = {
 		"makesContact": true,
 		"acc": 100
 	},
+	"Slam": {
+		"bp": 80,
+		"type": "Normal",
+		"category": "Physical",
+		"makesContact": true,
+		"acc": 75
+	},
 	"Slash": {
 		"bp": 70,
 		"type": "Normal",
 		"category": "Physical",
-		"alwaysCrit": true,
 		"makesContact": true,
 		"isSlicing": true,
 		"acc": 100
@@ -736,6 +756,13 @@ var MOVES_RBY = {
 		"type": "Bug",
 		"isTwoHit": true,
 		"hasSecondaryEffect": true,
+		"acc": 100
+	},
+	"Vise Grip": {
+		"bp": 55,
+		"type": "Normal",
+		"category": "Physical",
+		"makesContact": true,
 		"acc": 100
 	},
 	"Waterfall": {
@@ -1173,7 +1200,6 @@ var MOVES_GSC = $.extend(true, {}, MOVES_RBY, {
 		"hasSecondaryEffect": true,
 		"acc": 100
 	},
-	"Razor Leaf": {"alwaysCrit": false},
 	"Return": {
 		"bp": 102,
 		"type": "Normal",
@@ -1230,7 +1256,6 @@ var MOVES_GSC = $.extend(true, {}, MOVES_RBY, {
 		"isBullet": true,
 		"acc": 100
 	},
-	"Slash": {"alwaysCrit": false},
 	"Sleep Talk": {
 		"bp": 0,
 		"type": "Normal"

--- a/_scripts/honkalculate_calc.js
+++ b/_scripts/honkalculate_calc.js
@@ -244,13 +244,9 @@ function performCalculations() {
 				// < min, > max (I guess multihits? This would also come up if s toss was the max and min)
 				// > min, < max (s toss)
 				// < min, < max (worse move)
-				if (minDamage >= highestDamageMinRange && maxDamage > highestDamageMinRange) {
-					highestDamage = maxDamage;
-					highestDamageMinRange = minDamage;
-					highestN = n;
-				} else if (minDamage < highestDamageMinRange && maxDamage > highestDamageMinRange) {
-					// I think this case can be ignored
-				} else if (minDamage > highestDamageMinRange && maxDamage <= highestDamageMinRange) {
+				// I think the cases other than the two below can be ignored
+				if ((minDamage >= highestDamageMinRange && maxDamage > highestDamageMinRange) ||
+					(minDamage > highestDamageMinRange && maxDamage <= highestDamageMinRange)) {
 					highestDamage = maxDamage;
 					highestDamageMinRange = minDamage;
 					highestN = n;
@@ -274,7 +270,8 @@ function performCalculations() {
 				data.percentRange = minPercentage + " - " + maxPercentage + "%";
 				data.move = move.name.replace("Hidden Power", "HP");
 				// let setKOChanceText() do the math of whether something got the OHKO after hazards etc.
-				if (data.koChance === "guaranteed OHKO") {
+				if ((mode === "one-vs-all" && data.koChance === "guaranteed OHKO") ||
+					(mode === "all-vs-one" && data.koChance.includes("OHKO"))) {
 					ohkoCount++;
 				}
 			}

--- a/_scripts/shared_calc.js
+++ b/_scripts/shared_calc.js
@@ -1501,8 +1501,8 @@ function Side(format, terrain, weather, isAuraFairy, isAuraDark, isAuraBreak, is
 	this.isRuinBeads = isRuinBeads;
 }
 
-// note that this function only checks values against the current gen.
-function validateSetdex() {
+// note that this function only checks the setdex against the currently selected game.
+function validateSetdex(ignoreMoves = false) {
 	let failedValidation = false;
 	for (const [speciesName, speciesSets] of Object.entries(setdex)) {
 		if (!(speciesName in pokedex)) {
@@ -1518,8 +1518,9 @@ function validateSetdex() {
 		}
 		for (const [setName, setObj] of Object.entries(speciesSets)) {
 			let outputText = [];
-			if (setObj.item && items.indexOf(setObj.item) == -1) {
-				outputText.push("item " + setObj.item);
+			if (setObj.item && items.indexOf(setObj.item) == -1 &&
+				!(pokedexEntry.formes && pokedexEntry.formes[getFormeNum(setName, speciesName)].startsWith("Mega"))) {
+					outputText.push("item " + setObj.item);
 			}
 			if (pokedexEntry.abilities && setObj.ability && pokedexEntry.abilities.indexOf(setObj.ability) == -1) {
 				outputText.push("ability " + setObj.ability);
@@ -1527,15 +1528,17 @@ function validateSetdex() {
 			if (setObj.nature && !(setObj.nature in NATURES)) {
 				outputText.push("nature " + setObj.nature);
 			}
-			if (setObj.moves) {
-				for (let i = 0; i < setObj.length; i++) {
-					let moveName = setObj[i];
-					if (moveName && !(moveName in moves)) {
-						outputText.push("move " + moveName);
+			if (!ignoreMoves) {
+				if (setObj.moves) {
+					for (let i = 0; i < setObj.moves.length; i++) {
+						let moveName = setObj.moves[i];
+						if (moveName && !(moveName in moves)) {
+							outputText.push("move " + moveName);
+						}
 					}
+				} else {
+					outputText.push("no moves found");
 				}
-			} else {
-				outputText.push("no moves found");
 			}
 			if (outputText.length > 0) {
 				failedValidation = true;
@@ -1544,7 +1547,7 @@ function validateSetdex() {
 		}
 	}
 	if (!failedValidation) {
-		console.log("No validation issues found for gameId " + gameId + ".");
+		console.log("No " + (ignoreMoves ? "non-move " : "") + "validation issues found for gameId " + gameId + ".");
 	}
 }
 


### PR DESCRIPTION
- In the Allv1 mass calc, any move that has a chance to OHKO the user's Pokemon is now treated as an OHKO for the OHKO counter. This now contrasts the behavior for the 1vAll mass calc, which only counts opponents that are guaranteed OHKOs.
- In the 1v1 calc, the Pokemon with the higher speed stat has its speed stat bolded.
- The function used to validate the facility Pokemon sets did not properly validate the moves on those sets. The function has been fixed, and as a result several moves have been added to the list of moves.